### PR TITLE
docs: fix Claude Code plugin install command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ Claude Desktop configuration example:
 
 ```bash
 /plugin marketplace add gbbirkisson/mcp-oda
-/plugin install mcp-oda@gbbirkisson/mcp-oda
+/plugin install mcp-oda@mcp-oda
 ```
 
 #### Gemini CLI


### PR DESCRIPTION
The Claude Code install instructions in the README reference the marketplace by its GitHub path, but `/plugin install` expects the marketplace *name* — which is `mcp-oda` per `.claude-plugin/marketplace.json`.

Following the README as written fails on the second step:

```
❯ /plugin marketplace add gbbirkisson/mcp-oda
  ⎿  Successfully added marketplace: mcp-oda

❯ /plugin install mcp-oda@gbbirkisson/mcp-oda
  ⎿  Marketplace "gbbirkisson/mcp-oda" not found
```

This changes the install command to `/plugin install mcp-oda@mcp-oda`, which works.