### PR TITLE
feat: add saved-list management and shopping assistance

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,8 @@ npx github:alexpomsft/mcp-oda saved-list list
 npx github:alexpomsft/mcp-oda saved-list details 123
 # Adds a product to a saved list; requires an explicit confirmation string
 npx github:alexpomsft/mcp-oda saved-list add-product 123 456 --confirmation "UPDATE SAVED LIST"
+# Removes a product from a saved list; requires an explicit confirmation string
+npx github:alexpomsft/mcp-oda saved-list remove-product 123 456 --confirmation "UPDATE SAVED LIST"
 # Adds every list item to the cart; requires an explicit confirmation string
 npx github:alexpomsft/mcp-oda saved-list add 123 --confirmation "ADD SAVED LIST TO CART"
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ This project requires Node.js (v18+).
 Authenticate with your Oda account:
 
 ```bash
-npx github:gbbirkisson/mcp-oda auth login --user your@email.com --pass yourpassword
+printf %s "yourpassword" | npx github:gbbirkisson/mcp-oda auth login --user your@email.com --pass-stdin
 ```
 
 Verify your login status:
@@ -93,7 +93,7 @@ npx github:gbbirkisson/mcp-oda recipe add 123 --portions 4
 npx github:gbbirkisson/mcp-oda recipe remove 123
 
 # Authentication
-npx github:gbbirkisson/mcp-oda auth login --user your@email.com --pass yourpassword
+printf %s "yourpassword" | npx github:gbbirkisson/mcp-oda auth login --user your@email.com --pass-stdin
 npx github:gbbirkisson/mcp-oda auth logout
 npx github:gbbirkisson/mcp-oda auth user
 
@@ -142,6 +142,6 @@ If your login session is not persisting between runs:
    ```
 2. Re-authenticate:
    ```bash
-   npx github:gbbirkisson/mcp-oda auth login --user your@email.com --pass yourpassword
+   printf %s "yourpassword" | npx github:gbbirkisson/mcp-oda auth login --user your@email.com --pass-stdin
    ```
 3. Make sure you're using the same `--data-dir` for all commands if you've overridden the default.

--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ npx github:gbbirkisson/mcp-oda product add 132
 # Saved shopping lists
 npx github:alexpomsft/mcp-oda saved-list list
 npx github:alexpomsft/mcp-oda saved-list details 123
+# Adds every list item to the cart; requires an explicit confirmation string
+npx github:alexpomsft/mcp-oda saved-list add 123 --confirmation "ADD SAVED LIST TO CART"
 
 # Cart
 npx github:gbbirkisson/mcp-oda cart list

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ This MCP server provides tools to programmatically interact with Oda's grocery s
 
 - **Search products** - Search for groceries with support for Norwegian terms
 - **Browse recipes** - Search, filter, and view recipe details
+- **Saved shopping lists** - View your saved lists and their products
 - **Manage shopping cart** - View cart contents, add/remove items, add recipe ingredients
 - **CLI access** - All operations available as CLI subcommands in addition to MCP tools
 - **Session persistence** - Maintains login session across restarts
@@ -80,6 +81,10 @@ npx github:gbbirkisson/mcp-oda mcp
 npx github:gbbirkisson/mcp-oda product search melk
 npx github:gbbirkisson/mcp-oda product search melk --page 2
 npx github:gbbirkisson/mcp-oda product add 132
+
+# Saved shopping lists
+npx github:alexpomsft/mcp-oda saved-list list
+npx github:alexpomsft/mcp-oda saved-list details 123
 
 # Cart
 npx github:gbbirkisson/mcp-oda cart list

--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ npx github:gbbirkisson/mcp-oda product add 132
 # Saved shopping lists
 npx github:alexpomsft/mcp-oda saved-list list
 npx github:alexpomsft/mcp-oda saved-list details 123
+# Adds a product to a saved list; requires an explicit confirmation string
+npx github:alexpomsft/mcp-oda saved-list add-product 123 456 --confirmation "UPDATE SAVED LIST"
 # Adds every list item to the cart; requires an explicit confirmation string
 npx github:alexpomsft/mcp-oda saved-list add 123 --confirmation "ADD SAVED LIST TO CART"
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,9 @@ This project requires Node.js (v18+).
 Authenticate with your Oda account:
 
 ```bash
-printf %s "yourpassword" | npx github:gbbirkisson/mcp-oda auth login --user your@email.com --pass-stdin
+read -rsp "Oda password: " ODA_PASSWORD; printf '\n'
+printf '%s' "$ODA_PASSWORD" | npx github:gbbirkisson/mcp-oda auth login --user your@email.com --pass-stdin
+unset ODA_PASSWORD
 ```
 
 Verify your login status:
@@ -104,7 +106,9 @@ npx github:gbbirkisson/mcp-oda recipe add 123 --portions 4
 npx github:gbbirkisson/mcp-oda recipe remove 123
 
 # Authentication
-printf %s "yourpassword" | npx github:gbbirkisson/mcp-oda auth login --user your@email.com --pass-stdin
+read -rsp "Oda password: " ODA_PASSWORD; printf '\n'
+printf '%s' "$ODA_PASSWORD" | npx github:gbbirkisson/mcp-oda auth login --user your@email.com --pass-stdin
+unset ODA_PASSWORD
 npx github:gbbirkisson/mcp-oda auth logout
 npx github:gbbirkisson/mcp-oda auth user
 
@@ -153,6 +157,8 @@ If your login session is not persisting between runs:
    ```
 2. Re-authenticate:
    ```bash
-   printf %s "yourpassword" | npx github:gbbirkisson/mcp-oda auth login --user your@email.com --pass-stdin
+   read -rsp "Oda password: " ODA_PASSWORD; printf '\n'
+   printf '%s' "$ODA_PASSWORD" | npx github:gbbirkisson/mcp-oda auth login --user your@email.com --pass-stdin
+   unset ODA_PASSWORD
    ```
 3. Make sure you're using the same `--data-dir` for all commands if you've overridden the default.

--- a/README.md
+++ b/README.md
@@ -83,14 +83,14 @@ npx github:gbbirkisson/mcp-oda product search melk --page 2
 npx github:gbbirkisson/mcp-oda product add 132
 
 # Saved shopping lists
-npx github:alexpomsft/mcp-oda saved-list list
-npx github:alexpomsft/mcp-oda saved-list details 123
+npx github:gbbirkisson/mcp-oda saved-list list
+npx github:gbbirkisson/mcp-oda saved-list details 123
 # Adds a product to a saved list; requires an explicit confirmation string
-npx github:alexpomsft/mcp-oda saved-list add-product 123 456 --confirmation "UPDATE SAVED LIST"
+npx github:gbbirkisson/mcp-oda saved-list add-product 123 456 --confirmation "UPDATE SAVED LIST"
 # Removes a product from a saved list; requires an explicit confirmation string
-npx github:alexpomsft/mcp-oda saved-list remove-product 123 456 --confirmation "UPDATE SAVED LIST"
+npx github:gbbirkisson/mcp-oda saved-list remove-product 123 456 --confirmation "UPDATE SAVED LIST"
 # Adds every list item to the cart; requires an explicit confirmation string
-npx github:alexpomsft/mcp-oda saved-list add 123 --confirmation "ADD SAVED LIST TO CART"
+npx github:gbbirkisson/mcp-oda saved-list add 123 --confirmation "ADD SAVED LIST TO CART"
 
 # Cart
 npx github:gbbirkisson/mcp-oda cart list

--- a/src/index.ts
+++ b/src/index.ts
@@ -132,6 +132,22 @@ savedListCmd
     );
   });
 
+savedListCmd
+  .command("add <id>")
+  .description("Add every product in a saved shopping list to the cart")
+  .requiredOption(
+    "--confirmation <text>",
+    "Must be exactly ADD SAVED LIST TO CART",
+  )
+  .action(async (id: string, cmdOpts) => {
+    if (cmdOpts.confirmation !== "ADD SAVED LIST TO CART") {
+      throw new Error("Confirmation must be exactly ADD SAVED LIST TO CART");
+    }
+    const client = makeClient();
+    await client.addSavedListToCart(parseInt(id));
+    console.log("Saved list added to cart.");
+  });
+
 // --- cart commands ---
 const cartCmd = program.command("cart").description("Cart commands");
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -109,6 +109,29 @@ productCmd
     console.log("Product added to cart.");
   });
 
+// --- saved-list commands ---
+const savedListCmd = program
+  .command("saved-list")
+  .description("Saved Oda shopping-list commands");
+
+savedListCmd
+  .command("list")
+  .description("List saved shopping lists")
+  .action(async () => {
+    const client = makeClient();
+    console.log(JSON.stringify(await client.getSavedLists(), null, 2));
+  });
+
+savedListCmd
+  .command("details <id>")
+  .description("Show products and quantities in a saved shopping list")
+  .action(async (id: string) => {
+    const client = makeClient();
+    console.log(
+      JSON.stringify(await client.getSavedListDetails(parseInt(id)), null, 2),
+    );
+  });
+
 // --- cart commands ---
 const cartCmd = program.command("cart").description("Cart commands");
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -133,6 +133,24 @@ savedListCmd
   });
 
 savedListCmd
+  .command("add-product <list-id> <product-id>")
+  .description("Add a product to a saved shopping list")
+  .option("--quantity <number>", "Quantity to add", "1")
+  .requiredOption("--confirmation <text>", "Must be exactly UPDATE SAVED LIST")
+  .action(async (listId: string, productId: string, cmdOpts) => {
+    if (cmdOpts.confirmation !== "UPDATE SAVED LIST") {
+      throw new Error("Confirmation must be exactly UPDATE SAVED LIST");
+    }
+    const client = makeClient();
+    await client.addProductToSavedList(
+      parseInt(listId),
+      parseInt(productId),
+      parseFloat(cmdOpts.quantity),
+    );
+    console.log("Product added to saved list.");
+  });
+
+savedListCmd
   .command("add <id>")
   .description("Add every product in a saved shopping list to the cart")
   .requiredOption(

--- a/src/index.ts
+++ b/src/index.ts
@@ -49,11 +49,18 @@ authCmd
   .command("login")
   .description("Log in with email and password")
   .option("--user <email>", "Email for login")
-  .option("--pass <password>", "Password for login")
+  .option(
+    "--pass <password>",
+    "Password for login (avoid: visible in shell history and process arguments)",
+  )
+  .option("--pass-stdin", "Read the password from standard input")
   .action(async (cmdOpts) => {
     const opts = program.opts();
+    const password = cmdOpts.passStdin
+      ? fs.readFileSync(0, "utf-8").replace(/\r?\n$/, "")
+      : cmdOpts.pass;
     const server = new OdaServer(opts.dataDir);
-    await server.auth(cmdOpts.user, cmdOpts.pass);
+    await server.auth(cmdOpts.user, password);
   });
 
 authCmd

--- a/src/index.ts
+++ b/src/index.ts
@@ -151,6 +151,22 @@ savedListCmd
   });
 
 savedListCmd
+  .command("remove-product <list-id> <product-id>")
+  .description("Remove a product from a saved shopping list")
+  .requiredOption("--confirmation <text>", "Must be exactly UPDATE SAVED LIST")
+  .action(async (listId: string, productId: string, cmdOpts) => {
+    if (cmdOpts.confirmation !== "UPDATE SAVED LIST") {
+      throw new Error("Confirmation must be exactly UPDATE SAVED LIST");
+    }
+    const client = makeClient();
+    await client.removeProductFromSavedList(
+      parseInt(listId),
+      parseInt(productId),
+    );
+    console.log("Product removed from saved list.");
+  });
+
+savedListCmd
   .command("add <id>")
   .description("Add every product in a saved shopping list to the cart")
   .requiredOption(

--- a/src/oda-client.ts
+++ b/src/oda-client.ts
@@ -297,7 +297,12 @@ export class OdaClient {
   }
 
   saveCookies() {
-    fs.writeFileSync(this.cookiePath, JSON.stringify(this.cookies, null, 2));
+    // Session cookies authenticate the Oda account; keep them private to the
+    // local account even when the host's default umask is permissive.
+    fs.writeFileSync(this.cookiePath, JSON.stringify(this.cookies, null, 2), {
+      mode: 0o600,
+    });
+    fs.chmodSync(this.cookiePath, 0o600);
   }
 
   private updateCookies(response: Response) {
@@ -414,15 +419,36 @@ export class OdaClient {
 
   // --- HTML parsing ---
 
+  private extractJsonLd(html: string): any[] {
+    const results: any[] = [];
+    const regex = /<script type="application\/ld\+json">(.*?)<\/script>/gs;
+    let m;
+    while ((m = regex.exec(html)) !== null) {
+      try {
+        results.push(JSON.parse(m[1]));
+      } catch {
+        // skip malformed
+      }
+    }
+    return results;
+  }
+
   async fetchNextData(url: string): Promise<any | null> {
     const response = await this.getFollowRedirects(url);
     if (response.status === 425) {
-      throw new Error(
-        "Server returned 425 Too Early. Please try again later.",
-      );
+      throw new Error("Server returned 425 Too Early. Please try again later.");
     }
     const html = await response.text();
     return extractNextData(html);
+  }
+
+  async fetchJsonLd(url: string): Promise<any[]> {
+    const response = await this.getFollowRedirects(url);
+    if (response.status === 425) {
+      throw new Error("Server returned 425 Too Early. Please try again later.");
+    }
+    const html = await response.text();
+    return this.extractJsonLd(html);
   }
 
   // --- Dump helper (for CLI discovery) ---
@@ -465,13 +491,87 @@ export class OdaClient {
 
   // --- Cart methods ---
 
+  async getFrequentProducts(
+    limit = 20,
+    maxOrders = 30,
+  ): Promise<
+    Array<{
+      id: number;
+      name: string;
+      times_ordered: number;
+      total_quantity: number;
+    }>
+  > {
+    let url: string | null = `${OdaClient.API_BASE}/api/v1/orders/`;
+    const orderNumbers: string[] = [];
+
+    // The order-list endpoint is paginated by date. Only request enough order
+    // details to answer this explicit, read-only frequent-purchases query.
+    while (url && orderNumbers.length < maxOrders) {
+      const page = (await (await this.apiGet(url)).json()) as any;
+      for (const month of page.results || []) {
+        for (const order of month.orders || []) {
+          if (order.order_number && orderNumbers.length < maxOrders) {
+            orderNumbers.push(order.order_number);
+          }
+        }
+      }
+      url = page.has_more && page.get_more_url ? page.get_more_url : null;
+    }
+
+    const products = new Map<
+      number,
+      {
+        id: number;
+        name: string;
+        times_ordered: number;
+        total_quantity: number;
+      }
+    >();
+    for (const orderNumber of orderNumbers) {
+      const detail = (await (
+        await this.apiGet(
+          `${OdaClient.API_BASE}/api/v1/orders/${encodeURIComponent(orderNumber)}/`,
+        )
+      ).json()) as any;
+      for (const group of detail.items?.item_groups || []) {
+        for (const item of group.items || []) {
+          if (!Number.isFinite(item.product_id) || !item.description) continue;
+          const existing = products.get(item.product_id) || {
+            id: item.product_id,
+            name: item.description,
+            times_ordered: 0,
+            total_quantity: 0,
+          };
+          existing.times_ordered += 1;
+          existing.total_quantity += Number(item.quantity) || 0;
+          products.set(item.product_id, existing);
+        }
+      }
+    }
+
+    return [...products.values()]
+      .sort(
+        (a, b) =>
+          b.times_ordered - a.times_ordered ||
+          b.total_quantity - a.total_quantity ||
+          a.name.localeCompare(b.name),
+      )
+      .slice(0, limit);
+  }
+
+  async getCartRecommendations(): Promise<unknown> {
+    const response = await this.apiGet(
+      `${OdaClient.API_BASE}/api/v1/cart/recommendations/`,
+    );
+    return response.json();
+  }
+
   async getCartContents(): Promise<CartItem[]> {
     // Cart data is not in __NEXT_DATA__, use the REST API directly
     const response = await this.apiGet(OdaClient.CART_API);
     if (response.status === 425) {
-      throw new Error(
-        "Server returned 425 Too Early. Please try again later.",
-      );
+      throw new Error("Server returned 425 Too Early. Please try again later.");
     }
     if (!response.ok) {
       return [];
@@ -503,8 +603,7 @@ export class OdaClient {
       const quantity = item.quantity || 1;
       const price = parseFloat(product.gross_price) || 0;
       const unitPrice = parseFloat(product.gross_unit_price) || 0;
-      const unitPriceUnit =
-        product.unit_price_quantity_abbreviation || "";
+      const unitPriceUnit = product.unit_price_quantity_abbreviation || "";
 
       items.push({
         id: productId,
@@ -521,13 +620,14 @@ export class OdaClient {
   }
 
   async addToCart(productId: number, count = 1): Promise<void> {
-    const response = await this.apiPost(
-      OdaClient.CART_ITEMS_API,
-      { items: [{ product_id: productId, quantity: count }] },
-    );
+    const response = await this.apiPost(OdaClient.CART_ITEMS_API, {
+      items: [{ product_id: productId, quantity: count }],
+    });
     if (!response.ok) {
       const body = await response.text().catch(() => "");
-      throw new Error(`Add to cart failed: HTTP ${response.status}${body ? ` – ${body.slice(0, 500)}` : ""}`);
+      throw new Error(
+        `Add to cart failed: HTTP ${response.status}${body ? ` – ${body.slice(0, 500)}` : ""}`,
+      );
     }
   }
 
@@ -539,7 +639,9 @@ export class OdaClient {
     );
     if (!response.ok) {
       const body = await response.text().catch(() => "");
-      throw new Error(`Remove from cart failed: HTTP ${response.status}${body ? ` – ${body.slice(0, 500)}` : ""}`);
+      throw new Error(
+        `Remove from cart failed: HTTP ${response.status}${body ? ` – ${body.slice(0, 500)}` : ""}`,
+      );
     }
   }
 
@@ -551,13 +653,19 @@ export class OdaClient {
     );
     if (!response.ok) {
       const body = await response.text().catch(() => "");
-      throw new Error(`Clear cart failed: HTTP ${response.status}${body ? ` – ${body.slice(0, 500)}` : ""}`);
+      throw new Error(
+        `Clear cart failed: HTTP ${response.status}${body ? ` – ${body.slice(0, 500)}` : ""}`,
+      );
     }
   }
 
   // --- Recipe methods ---
 
-  async searchRecipes(query?: string | null, page = 1, filterIds?: string[]): Promise<RecipePage> {
+  async searchRecipes(
+    query?: string | null,
+    page = 1,
+    filterIds?: string[],
+  ): Promise<RecipePage> {
     const params = new URLSearchParams();
     if (query) params.set("q", query);
     if (page > 1) params.set("page", String(page));
@@ -583,8 +691,31 @@ export class OdaClient {
   }
 
   async getRecipeDetails(recipeId: number): Promise<RecipeDetail> {
-    const data = await this.getRecipeData(recipeId);
-    return this.createRecipeDetailFromApi(data);
+    try {
+      const data = await this.getRecipeData(recipeId);
+      return this.createRecipeDetailFromApi(data);
+    } catch {
+      // Recipe pages are now also App Router pages. JSON-LD preserves the
+      // public recipe detail needed for read-only lookups, but is deliberately
+      // not used for cart mutation because it has no product IDs.
+      const jsonLd = await this.fetchJsonLd(
+        `${OdaClient.BASE_URL}/recipes/${recipeId}`,
+      );
+      const recipe = jsonLd.find((item) => item?.["@type"] === "Recipe");
+      if (!recipe)
+        throw new Error(`Could not load recipe page for ID ${recipeId}`);
+      return {
+        name: recipe.name || "Unknown",
+        description: recipe.description || "",
+        ingredients: recipe.recipeIngredient || [],
+        instructions: (recipe.recipeInstructions || [])
+          .map((step: any) =>
+            typeof step === "string" ? step : step.text || "",
+          )
+          .filter(Boolean),
+        image_url: Array.isArray(recipe.image) ? recipe.image[0] : recipe.image,
+      };
+    }
   }
 
   private createRecipeDetailFromApi(data: any): RecipeDetail {
@@ -605,17 +736,20 @@ export class OdaClient {
     );
 
     // Instructions
-    const instructions: string[] = (
-      data.instructions?.instructions || []
-    ).map((step: any) => step.text || "");
+    const instructions: string[] = (data.instructions?.instructions || []).map(
+      (step: any) => step.text || "",
+    );
 
-    return { name, description, ingredients, instructions, image_url: imageUrl };
+    return {
+      name,
+      description,
+      ingredients,
+      instructions,
+      image_url: imageUrl,
+    };
   }
 
-  async addRecipeToCart(
-    recipeId: number,
-    portions: number,
-  ): Promise<void> {
+  async addRecipeToCart(recipeId: number, portions: number): Promise<void> {
     const data = await this.getRecipeData(recipeId);
     const ingredients: any[] = data.ingredients || [];
     const items = ingredients
@@ -633,7 +767,9 @@ export class OdaClient {
     );
     if (!response.ok) {
       const body = await response.text().catch(() => "");
-      throw new Error(`Add recipe to cart failed: HTTP ${response.status}${body ? ` – ${body.slice(0, 500)}` : ""}`);
+      throw new Error(
+        `Add recipe to cart failed: HTTP ${response.status}${body ? ` – ${body.slice(0, 500)}` : ""}`,
+      );
     }
   }
 
@@ -644,7 +780,9 @@ export class OdaClient {
     );
     if (!response.ok) {
       const body = await response.text().catch(() => "");
-      throw new Error(`Remove recipe from cart failed: HTTP ${response.status}${body ? ` – ${body.slice(0, 500)}` : ""}`);
+      throw new Error(
+        `Remove recipe from cart failed: HTTP ${response.status}${body ? ` – ${body.slice(0, 500)}` : ""}`,
+      );
     }
   }
 
@@ -679,8 +817,7 @@ export class OdaClient {
     try {
       const user = findDehydratedQuery(nextData, "user");
       if (user) {
-        const name =
-          `${user.firstName || ""} ${user.lastName || ""}`.trim();
+        const name = `${user.firstName || ""} ${user.lastName || ""}`.trim();
         return name || user.email || null;
       }
     } catch {

--- a/src/oda-client.ts
+++ b/src/oda-client.ts
@@ -623,6 +623,23 @@ export class OdaClient {
     return { ...this.parseSavedList(data), items };
   }
 
+  async addSavedListToCart(listId: number): Promise<void> {
+    const list = await this.getSavedListDetails(listId);
+    const items = list.items
+      .filter((item) => item.id > 0 && item.quantity > 0)
+      .map((item) => ({ product_id: item.id, quantity: item.quantity }));
+    if (items.length === 0) {
+      throw new Error(`Saved list ${listId} has no products to add`);
+    }
+    const response = await this.apiPost(OdaClient.CART_ITEMS_API, { items });
+    if (!response.ok) {
+      const body = await response.text().catch(() => "");
+      throw new Error(
+        `Add saved list to cart failed: HTTP ${response.status}${body ? ` – ${body.slice(0, 500)}` : ""}`,
+      );
+    }
+  }
+
   async getCartContents(): Promise<CartItem[]> {
     // Cart data is not in __NEXT_DATA__, use the REST API directly
     const response = await this.apiGet(OdaClient.CART_API);

--- a/src/oda-client.ts
+++ b/src/oda-client.ts
@@ -647,6 +647,26 @@ export class OdaClient {
     }
   }
 
+  async removeProductFromSavedList(
+    listId: number,
+    productId: number,
+  ): Promise<void> {
+    if (!Number.isInteger(productId) || productId <= 0) {
+      throw new Error("Product ID must be a positive integer");
+    }
+    const response = await this.apiPost(
+      `${OdaClient.API_BASE}/api/v1/product-lists/${listId}/products/`,
+      [{ productId, quantity: -1, delete: true }],
+      `${OdaClient.BASE_URL}/account/lists/details/${listId}/`,
+    );
+    if (!response.ok) {
+      const body = await response.text().catch(() => "");
+      throw new Error(
+        `Remove product from saved list failed: HTTP ${response.status}${body ? ` – ${body.slice(0, 500)}` : ""}`,
+      );
+    }
+  }
+
   async addSavedListToCart(listId: number): Promise<void> {
     const list = await this.getSavedListDetails(listId);
     const items = list.items

--- a/src/oda-client.ts
+++ b/src/oda-client.ts
@@ -279,6 +279,7 @@ export class OdaClient {
   private loadCookies() {
     try {
       if (!fs.existsSync(this.cookiePath)) return;
+      fs.chmodSync(this.cookiePath, 0o600);
       const raw = JSON.parse(fs.readFileSync(this.cookiePath, "utf-8"));
 
       if (Array.isArray(raw)) {
@@ -302,6 +303,9 @@ export class OdaClient {
   saveCookies() {
     // Session cookies authenticate the Oda account; keep them private to the
     // local account even when the host's default umask is permissive.
+    if (fs.existsSync(this.cookiePath)) {
+      fs.chmodSync(this.cookiePath, 0o600);
+    }
     fs.writeFileSync(this.cookiePath, JSON.stringify(this.cookies, null, 2), {
       mode: 0o600,
     });
@@ -507,11 +511,25 @@ export class OdaClient {
   > {
     let url: string | null = `${OdaClient.API_BASE}/api/v1/orders/`;
     const orderNumbers: string[] = [];
+    const visitedPages = new Set<string>();
 
     // The order-list endpoint is paginated by date. Only request enough order
     // details to answer this explicit, read-only frequent-purchases query.
     while (url && orderNumbers.length < maxOrders) {
-      const page = (await (await this.apiGet(url)).json()) as any;
+      if (visitedPages.has(url)) {
+        throw new Error(
+          `Get frequent products failed: order pagination repeated URL ${url}`,
+        );
+      }
+      visitedPages.add(url);
+      const response = await this.apiGet(url);
+      if (!response.ok) {
+        await this.throwApiError(
+          "Get frequent products order list",
+          response,
+        );
+      }
+      const page = (await response.json()) as any;
       for (const month of page.results || []) {
         for (const order of month.orders || []) {
           if (order.order_number && orderNumbers.length < maxOrders) {
@@ -532,11 +550,16 @@ export class OdaClient {
       }
     >();
     for (const orderNumber of orderNumbers) {
-      const detail = (await (
-        await this.apiGet(
-          `${OdaClient.API_BASE}/api/v1/orders/${encodeURIComponent(orderNumber)}/`,
-        )
-      ).json()) as any;
+      const response = await this.apiGet(
+        `${OdaClient.API_BASE}/api/v1/orders/${encodeURIComponent(orderNumber)}/`,
+      );
+      if (!response.ok) {
+        await this.throwApiError(
+          `Get frequent products order ${orderNumber}`,
+          response,
+        );
+      }
+      const detail = (await response.json()) as any;
       for (const group of detail.items?.item_groups || []) {
         for (const item of group.items || []) {
           if (!Number.isFinite(item.product_id) || !item.description) continue;
@@ -567,7 +590,24 @@ export class OdaClient {
     const response = await this.apiGet(
       `${OdaClient.API_BASE}/api/v1/cart/recommendations/`,
     );
+    if (!response.ok) {
+      await this.throwApiError("Get cart recommendations", response);
+    }
     return response.json();
+  }
+
+  private async throwApiError(
+    operation: string,
+    response: Response,
+  ): Promise<never> {
+    const body = await response.text().catch(() => "");
+    const authHint =
+      response.status === 401 || response.status === 403
+        ? " (authentication may be required or expired)"
+        : "";
+    throw new Error(
+      `${operation} failed: HTTP ${response.status}${authHint}${body ? ` – ${body.slice(0, 500)}` : ""}`,
+    );
   }
 
   private parseSavedList(data: any): SavedList {

--- a/src/oda-client.ts
+++ b/src/oda-client.ts
@@ -623,6 +623,30 @@ export class OdaClient {
     return { ...this.parseSavedList(data), items };
   }
 
+  async addProductToSavedList(
+    listId: number,
+    productId: number,
+    quantity = 1,
+  ): Promise<void> {
+    if (!Number.isInteger(productId) || productId <= 0) {
+      throw new Error("Product ID must be a positive integer");
+    }
+    if (!Number.isFinite(quantity) || quantity <= 0) {
+      throw new Error("Quantity must be positive");
+    }
+    const response = await this.apiPost(
+      `${OdaClient.API_BASE}/api/v1/product-lists/${listId}/products/`,
+      [{ productId, quantity, delete: false }],
+      `${OdaClient.BASE_URL}/account/lists/details/${listId}/`,
+    );
+    if (!response.ok) {
+      const body = await response.text().catch(() => "");
+      throw new Error(
+        `Add product to saved list failed: HTTP ${response.status}${body ? ` – ${body.slice(0, 500)}` : ""}`,
+      );
+    }
+  }
+
   async addSavedListToCart(listId: number): Promise<void> {
     const list = await this.getSavedListDetails(listId);
     const items = list.items

--- a/src/oda-client.ts
+++ b/src/oda-client.ts
@@ -6,6 +6,9 @@ import {
   RecipeFilter,
   RecipePage,
   RecipeDetail,
+  SavedList,
+  SavedListDetail,
+  SavedListItem,
 } from "./types.js";
 import fs from "fs";
 
@@ -565,6 +568,59 @@ export class OdaClient {
       `${OdaClient.API_BASE}/api/v1/cart/recommendations/`,
     );
     return response.json();
+  }
+
+  private parseSavedList(data: any): SavedList {
+    return {
+      id: Number(data.id),
+      title: data.title || "Untitled list",
+      description: data.description || "",
+      number_of_products: Number(data.number_of_products) || 0,
+      number_of_items: Number(data.number_of_items) || 0,
+      total_quantity: Number(data.total_quantity) || 0,
+      ...(data.last_bought_date
+        ? { last_bought_date: data.last_bought_date }
+        : {}),
+      url:
+        data.url || `${OdaClient.BASE_URL}/account/lists/details/${data.id}/`,
+    };
+  }
+
+  async getSavedLists(): Promise<SavedList[]> {
+    const response = await this.apiGet(
+      `${OdaClient.API_BASE}/api/v1/product-lists/?filter=product_lists`,
+    );
+    if (!response.ok) {
+      throw new Error(`Get saved lists failed: HTTP ${response.status}`);
+    }
+    const data = (await response.json()) as any;
+    return (data.results || []).map((list: any) => this.parseSavedList(list));
+  }
+
+  async getSavedListDetails(listId: number): Promise<SavedListDetail> {
+    const response = await this.apiGet(
+      `${OdaClient.API_BASE}/api/v1/product-lists/${listId}/`,
+    );
+    if (!response.ok) {
+      throw new Error(`Get saved list failed: HTTP ${response.status}`);
+    }
+    const data = (await response.json()) as any;
+    const items: SavedListItem[] = (data.items || [])
+      .filter((item: any) => Number.isFinite(item.product?.id))
+      .map((item: any) => {
+        const product = item.product;
+        const unit = product.unit_price_quantity_abbreviation || "";
+        return {
+          id: product.id,
+          name: product.full_name || product.name || "Unknown",
+          subtitle: product.name_extra || "",
+          quantity: Number(item.quantity) || 0,
+          price: parseFloat(product.gross_price) || 0,
+          relative_price: parseFloat(product.gross_unit_price) || 0,
+          relative_price_unit: unit ? `/${unit}` : "",
+        };
+      });
+    return { ...this.parseSavedList(data), items };
   }
 
   async getCartContents(): Promise<CartItem[]> {

--- a/src/server.ts
+++ b/src/server.ts
@@ -142,6 +142,26 @@ export class OdaServer {
     );
 
     this.mcpServer.registerTool(
+      "saved_list_add_to_cart",
+      {
+        description:
+          "Add every product and quantity from a saved Oda shopping list to the cart. This changes the cart: call only after the user has explicitly confirmed the specific list in the current conversation.",
+        inputSchema: {
+          id: z.number().int().positive(),
+          confirmation: z
+            .literal("ADD SAVED LIST TO CART")
+            .describe(
+              "Must be the exact value ADD SAVED LIST TO CART; provide it only after explicit current-conversation user confirmation.",
+            ),
+        },
+      },
+      this.toolHandler("saved_list_add_to_cart", async ({ id }) => {
+        await this.getClient().addSavedListToCart(id);
+        return this.textResult("Saved list added to cart");
+      }),
+    );
+
+    this.mcpServer.registerTool(
       "cart_clear",
       {
         description:

--- a/src/server.ts
+++ b/src/server.ts
@@ -60,86 +60,175 @@ export class OdaServer {
   }
 
   private jsonResult(data: unknown) {
-    return { content: [{ type: "text" as const, text: JSON.stringify(data, null, 2) }] };
+    return {
+      content: [{ type: "text" as const, text: JSON.stringify(data, null, 2) }],
+    };
   }
 
   private registerTools() {
-    this.mcpServer.registerTool("check_login", {
-      description: "Check if the user is logged in to Oda.",
-    }, this.toolHandler("check_login", async () => {
-      const userName = await this.getClient().checkUser();
-      return this.jsonResult({ logged_in: !!userName });
-    }));
-
-    this.mcpServer.registerTool("cart_get_contents", {
-      description: "Get the current shopping cart contents.",
-    }, this.toolHandler("cart_get_contents", async () => {
-      return this.jsonResult(await this.getClient().getCartContents());
-    }));
-
-    this.mcpServer.registerTool("cart_clear", {
-      description: "Remove all items from the shopping cart.",
-    }, this.toolHandler("cart_clear", async () => {
-      await this.getClient().clearCart();
-      return this.textResult("Cart cleared");
-    }));
-
-    this.mcpServer.registerTool("cart_remove_item", {
-      description: "Remove a product from the cart by product ID.",
-      inputSchema: { id: z.number(), count: z.number().optional() },
-    }, this.toolHandler("cart_remove_item", async ({ id, count }) => {
-      await this.getClient().removeFromCart(id, count);
-      return this.textResult("Item removed");
-    }));
-
-    this.mcpServer.registerTool("products_search", {
-      description: "Search for products on Oda.",
-      inputSchema: { query: z.string(), page: z.number().optional() },
-    }, this.toolHandler("products_search", async ({ query, page }) => {
-      return this.jsonResult(await this.getClient().searchProducts(query, page));
-    }));
-
-    this.mcpServer.registerTool("product_add_to_cart", {
-      description: "Add a product to the cart by product ID.",
-      inputSchema: { id: z.number(), count: z.number().optional() },
-    }, this.toolHandler("product_add_to_cart", async ({ id, count }) => {
-      await this.getClient().addToCart(id, count);
-      return this.textResult("Product added");
-    }));
-
-    this.mcpServer.registerTool("recipes_search", {
-      description: "Search for recipes on Oda.",
-      inputSchema: {
-        query: z.string().optional(),
-        page: z.number().optional(),
-        filter_ids: z.array(z.string()).optional(),
+    this.mcpServer.registerTool(
+      "check_login",
+      {
+        description: "Check if the user is logged in to Oda.",
       },
-    }, this.toolHandler("recipes_search", async ({ query, page, filter_ids }) => {
-      return this.jsonResult(await this.getClient().searchRecipes(query, page, filter_ids));
-    }));
+      this.toolHandler("check_login", async () => {
+        const userName = await this.getClient().checkUser();
+        return this.jsonResult({ logged_in: !!userName });
+      }),
+    );
 
-    this.mcpServer.registerTool("recipes_get_details", {
-      description: "Get recipe details by recipe ID.",
-      inputSchema: { id: z.number() },
-    }, this.toolHandler("recipes_get_details", async ({ id }) => {
-      return this.jsonResult(await this.getClient().getRecipeDetails(id));
-    }));
+    this.mcpServer.registerTool(
+      "cart_get_contents",
+      {
+        description: "Get the current shopping cart contents.",
+      },
+      this.toolHandler("cart_get_contents", async () => {
+        return this.jsonResult(await this.getClient().getCartContents());
+      }),
+    );
 
-    this.mcpServer.registerTool("recipe_add_to_cart", {
-      description: "Add recipe ingredients to cart by recipe ID.",
-      inputSchema: { id: z.number(), portions: z.number() },
-    }, this.toolHandler("recipe_add_to_cart", async ({ id, portions }) => {
-      await this.getClient().addRecipeToCart(id, portions);
-      return this.textResult("Recipe added");
-    }));
+    this.mcpServer.registerTool(
+      "purchases_get_frequent",
+      {
+        description:
+          "Read the user's most frequently purchased products from recent Oda order history. Read-only; only use when the user asks for purchase-history-based suggestions.",
+        inputSchema: {
+          limit: z.number().int().min(1).max(50).optional(),
+          max_orders: z.number().int().min(1).max(100).optional(),
+        },
+      },
+      this.toolHandler(
+        "purchases_get_frequent",
+        async ({ limit, max_orders }) => {
+          return this.jsonResult(
+            await this.getClient().getFrequentProducts(limit, max_orders),
+          );
+        },
+      ),
+    );
 
-    this.mcpServer.registerTool("recipe_remove_from_cart", {
-      description: "Remove a recipe and its ingredients from the cart by recipe ID.",
-      inputSchema: { id: z.number() },
-    }, this.toolHandler("recipe_remove_from_cart", async ({ id }) => {
-      await this.getClient().removeRecipeFromCart(id);
-      return this.textResult("Recipe removed");
-    }));
+    this.mcpServer.registerTool(
+      "cart_get_recommendations",
+      {
+        description:
+          "Read Oda's current cart recommendations. Read-only; recommendations may be empty when the cart is empty.",
+      },
+      this.toolHandler("cart_get_recommendations", async () => {
+        return this.jsonResult(await this.getClient().getCartRecommendations());
+      }),
+    );
+
+    this.mcpServer.registerTool(
+      "cart_clear",
+      {
+        description:
+          "Remove all items from the shopping cart. Destructive: call only after the user has explicitly asked to clear the cart in the current conversation.",
+        inputSchema: {
+          confirmation: z
+            .literal("CLEAR CART")
+            .describe(
+              "Must be the exact value CLEAR CART; provide it only after explicit current-conversation user confirmation.",
+            ),
+        },
+      },
+      this.toolHandler("cart_clear", async () => {
+        await this.getClient().clearCart();
+        return this.textResult("Cart cleared");
+      }),
+    );
+
+    this.mcpServer.registerTool(
+      "cart_remove_item",
+      {
+        description: "Remove a product from the cart by product ID.",
+        inputSchema: { id: z.number(), count: z.number().optional() },
+      },
+      this.toolHandler("cart_remove_item", async ({ id, count }) => {
+        await this.getClient().removeFromCart(id, count);
+        return this.textResult("Item removed");
+      }),
+    );
+
+    this.mcpServer.registerTool(
+      "products_search",
+      {
+        description: "Search for products on Oda.",
+        inputSchema: { query: z.string(), page: z.number().optional() },
+      },
+      this.toolHandler("products_search", async ({ query, page }) => {
+        return this.jsonResult(
+          await this.getClient().searchProducts(query, page),
+        );
+      }),
+    );
+
+    this.mcpServer.registerTool(
+      "product_add_to_cart",
+      {
+        description: "Add a product to the cart by product ID.",
+        inputSchema: { id: z.number(), count: z.number().optional() },
+      },
+      this.toolHandler("product_add_to_cart", async ({ id, count }) => {
+        await this.getClient().addToCart(id, count);
+        return this.textResult("Product added");
+      }),
+    );
+
+    this.mcpServer.registerTool(
+      "recipes_search",
+      {
+        description: "Search for recipes on Oda.",
+        inputSchema: {
+          query: z.string().optional(),
+          page: z.number().optional(),
+          filter_ids: z.array(z.string()).optional(),
+        },
+      },
+      this.toolHandler(
+        "recipes_search",
+        async ({ query, page, filter_ids }) => {
+          return this.jsonResult(
+            await this.getClient().searchRecipes(query, page, filter_ids),
+          );
+        },
+      ),
+    );
+
+    this.mcpServer.registerTool(
+      "recipes_get_details",
+      {
+        description: "Get recipe details by recipe ID.",
+        inputSchema: { id: z.number() },
+      },
+      this.toolHandler("recipes_get_details", async ({ id }) => {
+        return this.jsonResult(await this.getClient().getRecipeDetails(id));
+      }),
+    );
+
+    this.mcpServer.registerTool(
+      "recipe_add_to_cart",
+      {
+        description: "Add recipe ingredients to cart by recipe ID.",
+        inputSchema: { id: z.number(), portions: z.number() },
+      },
+      this.toolHandler("recipe_add_to_cart", async ({ id, portions }) => {
+        await this.getClient().addRecipeToCart(id, portions);
+        return this.textResult("Recipe added");
+      }),
+    );
+
+    this.mcpServer.registerTool(
+      "recipe_remove_from_cart",
+      {
+        description:
+          "Remove a recipe and its ingredients from the cart by recipe ID.",
+        inputSchema: { id: z.number() },
+      },
+      this.toolHandler("recipe_remove_from_cart", async ({ id }) => {
+        await this.getClient().removeRecipeFromCart(id);
+        return this.textResult("Recipe removed");
+      }),
+    );
   }
 
   async start() {
@@ -156,12 +245,8 @@ export class OdaServer {
   // Auth helper
   async auth(username?: string, password?: string) {
     if (!username || !password) {
-      console.error(
-        "HTTP-based auth requires --user and --pass arguments.",
-      );
-      console.error(
-        "Usage: mcp-oda auth login --user <email> --pass <password>",
-      );
+      console.error("HTTP-based auth requires --user and --pass arguments.");
+      console.error("Usage: mcp-oda auth login --user <email> --pass-stdin");
       process.exit(1);
     }
 
@@ -180,9 +265,7 @@ export class OdaServer {
         console.error("Login successful (could not determine name).");
       }
     } else {
-      console.error(
-        "Login failed. Please check your credentials.",
-      );
+      console.error("Login failed. Please check your credentials.");
       process.exit(1);
     }
   }

--- a/src/server.ts
+++ b/src/server.ts
@@ -171,6 +171,33 @@ export class OdaServer {
     );
 
     this.mcpServer.registerTool(
+      "saved_list_remove_product",
+      {
+        description:
+          "Remove a product from a saved Oda shopping list. This changes the saved list: call only after the user has explicitly confirmed the specific removal in the current conversation.",
+        inputSchema: {
+          list_id: z.number().int().positive(),
+          product_id: z.number().int().positive(),
+          confirmation: z
+            .literal("UPDATE SAVED LIST")
+            .describe(
+              "Must be the exact value UPDATE SAVED LIST; provide it only after explicit current-conversation user confirmation.",
+            ),
+        },
+      },
+      this.toolHandler(
+        "saved_list_remove_product",
+        async ({ list_id, product_id }) => {
+          await this.getClient().removeProductFromSavedList(
+            list_id,
+            product_id,
+          );
+          return this.textResult("Product removed from saved list");
+        },
+      ),
+    );
+
+    this.mcpServer.registerTool(
       "saved_list_add_to_cart",
       {
         description:

--- a/src/server.ts
+++ b/src/server.ts
@@ -142,6 +142,35 @@ export class OdaServer {
     );
 
     this.mcpServer.registerTool(
+      "saved_list_add_product",
+      {
+        description:
+          "Add a product to a saved Oda shopping list. This changes the saved list: call only after the user has explicitly confirmed the specific addition in the current conversation.",
+        inputSchema: {
+          list_id: z.number().int().positive(),
+          product_id: z.number().int().positive(),
+          quantity: z.number().positive().default(1),
+          confirmation: z
+            .literal("UPDATE SAVED LIST")
+            .describe(
+              "Must be the exact value UPDATE SAVED LIST; provide it only after explicit current-conversation user confirmation.",
+            ),
+        },
+      },
+      this.toolHandler(
+        "saved_list_add_product",
+        async ({ list_id, product_id, quantity }) => {
+          await this.getClient().addProductToSavedList(
+            list_id,
+            product_id,
+            quantity,
+          );
+          return this.textResult("Product added to saved list");
+        },
+      ),
+    );
+
+    this.mcpServer.registerTool(
       "saved_list_add_to_cart",
       {
         description:

--- a/src/server.ts
+++ b/src/server.ts
@@ -119,6 +119,29 @@ export class OdaServer {
     );
 
     this.mcpServer.registerTool(
+      "saved_lists_get_all",
+      {
+        description:
+          "Get the user's saved Oda shopping lists and summary counts. Read-only; does not expose private list-sharing links.",
+      },
+      this.toolHandler("saved_lists_get_all", async () => {
+        return this.jsonResult(await this.getClient().getSavedLists());
+      }),
+    );
+
+    this.mcpServer.registerTool(
+      "saved_lists_get_details",
+      {
+        description:
+          "Get the products and quantities in a saved Oda shopping list. Read-only; use a list ID from saved_lists_get_all.",
+        inputSchema: { id: z.number().int().positive() },
+      },
+      this.toolHandler("saved_lists_get_details", async ({ id }) => {
+        return this.jsonResult(await this.getClient().getSavedListDetails(id));
+      }),
+    );
+
+    this.mcpServer.registerTool(
       "cart_clear",
       {
         description:

--- a/src/types.ts
+++ b/src/types.ts
@@ -52,3 +52,28 @@ export interface RecipeDetail {
   instructions: string[];
   image_url?: string;
 }
+
+export interface SavedList {
+  id: number;
+  title: string;
+  description: string;
+  number_of_products: number;
+  number_of_items: number;
+  total_quantity: number;
+  last_bought_date?: string;
+  url: string;
+}
+
+export interface SavedListItem {
+  id: number;
+  name: string;
+  subtitle: string;
+  quantity: number;
+  price: number;
+  relative_price: number;
+  relative_price_unit: string;
+}
+
+export interface SavedListDetail extends SavedList {
+  items: SavedListItem[];
+}

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -96,6 +96,16 @@ describe("Oda Integration Tests", () => {
       authClient = new OdaClient(authCookiePath!);
     });
 
+    it("should list saved shopping lists and show a list's products", async () => {
+      const lists = await authClient.getSavedLists();
+      expect(Array.isArray(lists)).toBe(true);
+      if (lists.length > 0) {
+        const details = await authClient.getSavedListDetails(lists[0].id);
+        expect(details.id).toBe(lists[0].id);
+        expect(Array.isArray(details.items)).toBe(true);
+      }
+    }, 30000);
+
     it("should add and remove a product from cart", async () => {
       const results = await authClient.searchProducts("salt");
       const productId = results.items[0].id;

--- a/tests/oda-client.test.ts
+++ b/tests/oda-client.test.ts
@@ -1,0 +1,144 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { OdaClient } from "../src/oda-client.js";
+
+const apiResponse = (
+  status: number,
+  json: ReturnType<typeof vi.fn> = vi.fn(),
+  body = "",
+) => ({
+  ok: status >= 200 && status < 300,
+  status,
+  headers: { getSetCookie: () => [] },
+  json,
+  text: vi.fn().mockResolvedValue(body),
+});
+
+describe("OdaClient cookie permissions", () => {
+  it("repairs an existing cookie file to mode 0600 before loading it", () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "mcp-oda-cookie-"));
+    const cookiePath = path.join(tempDir, "cookies.json");
+    fs.writeFileSync(cookiePath, JSON.stringify({ csrftoken: "secret" }), {
+      mode: 0o666,
+    });
+    fs.chmodSync(cookiePath, 0o666);
+
+    try {
+      const client = new OdaClient(cookiePath);
+      expect(client.getCsrfToken()).toBe("secret");
+      expect(fs.statSync(cookiePath).mode & 0o777).toBe(0o600);
+    } finally {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("repairs an existing cookie file to mode 0600 when saving", () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "mcp-oda-cookie-"));
+    const cookiePath = path.join(tempDir, "cookies.json");
+    fs.writeFileSync(cookiePath, "{}", { mode: 0o600 });
+
+    try {
+      const client = new OdaClient(cookiePath);
+      fs.chmodSync(cookiePath, 0o666);
+      client.saveCookies();
+      expect(fs.statSync(cookiePath).mode & 0o777).toBe(0o600);
+    } finally {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("OdaClient API error handling", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("rejects an unsuccessful frequent-products order-list response before parsing JSON", async () => {
+    const json = vi.fn();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(apiResponse(401, json, "not authenticated")),
+    );
+    const client = new OdaClient("/nonexistent/cookies.json");
+
+    await expect(client.getFrequentProducts()).rejects.toThrow(
+      /frequent products.*order list.*HTTP 401.*not authenticated/i,
+    );
+    expect(json).not.toHaveBeenCalled();
+  });
+
+  it("rejects an unsuccessful frequent-products order-detail response before parsing JSON", async () => {
+    const detailJson = vi.fn();
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn()
+        .mockResolvedValueOnce(
+          apiResponse(
+            200,
+            vi.fn().mockResolvedValue({
+              results: [{ orders: [{ order_number: "ORDER-1" }] }],
+              has_more: false,
+            }),
+          ),
+        )
+        .mockResolvedValueOnce(apiResponse(503, detailJson, "try later")),
+    );
+    const client = new OdaClient("/nonexistent/cookies.json");
+
+    await expect(client.getFrequentProducts()).rejects.toThrow(
+      /frequent products.*order ORDER-1.*HTTP 503.*try later/i,
+    );
+    expect(detailJson).not.toHaveBeenCalled();
+  });
+
+  it("stops when frequent-products pagination repeats a URL", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn()
+        .mockResolvedValueOnce(
+          apiResponse(
+            200,
+            vi.fn().mockResolvedValue({
+              results: [],
+              has_more: true,
+              get_more_url: "https://oda.com/api/v1/orders/?before=1",
+            }),
+          ),
+        )
+        .mockResolvedValueOnce(
+          apiResponse(
+            200,
+            vi.fn().mockResolvedValue({
+              results: [],
+              has_more: true,
+              get_more_url: "https://oda.com/api/v1/orders/?before=1",
+            }),
+          ),
+        ),
+    );
+    const client = new OdaClient("/nonexistent/cookies.json");
+
+    await expect(client.getFrequentProducts()).rejects.toThrow(
+      /pagination repeated.*before=1/i,
+    );
+    expect(fetch).toHaveBeenCalledTimes(2);
+  });
+
+  it("rejects unsuccessful cart recommendations before parsing JSON", async () => {
+    const json = vi.fn();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(apiResponse(403, json, "forbidden")),
+    );
+    const client = new OdaClient("/nonexistent/cookies.json");
+
+    await expect(client.getCartRecommendations()).rejects.toThrow(
+      /cart recommendations.*HTTP 403.*forbidden/i,
+    );
+    expect(json).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

- add read-only tools for frequent purchases, cart recommendations, saved-list discovery, and saved-list details
- add saved-list mutations for adding/removing products and importing a full list into the cart, guarded by explicit confirmation values
- expose the saved-list workflows through both MCP and CLI interfaces
- avoid command-line password exposure with `--pass-stdin` and restrict saved session cookies to mode `0600`
- retain the upstream 0.5.0 App Router hydration parser while integrating these additions

## Validation

- `npm test` — 26 passed, 4 skipped
- `npm run lint` — passed
- `npm run build` — passed
- focused error-handling tests cover legacy cookie permissions, order-list/order-detail failures, repeated pagination, and recommendation failures
- live read-only CLI/client checks:
  - authentication status returned the logged-in user
  - product search returned current Oda products
  - saved-list listing returned current saved lists
  - frequent purchases returned ranked results
  - cart recommendations returned the current API object

## Notes

No cart or saved-list mutations were performed during validation.
