### PR TITLE
fix: raise on cart fetch failures instead of returning an empty cart

### DIFF
--- a/src/oda-client.ts
+++ b/src/oda-client.ts
@@ -838,16 +838,17 @@ export class OdaClient {
       throw new Error("Server returned 425 Too Early. Please try again later.");
     }
     if (!response.ok) {
-      return [];
+      // An expired session must not look like an empty cart
+      await this.throwApiError("Get cart", response);
     }
 
+    let data: any;
     try {
-      const data = await response.json();
-      return this.parseCartApi(data);
+      data = await response.json();
     } catch (e) {
-      console.error("Failed to parse cart API response", e);
-      return [];
+      throw new Error(`Get cart failed: unparseable response (${e})`);
     }
+    return this.parseCartApi(data);
   }
 
   private parseCartApi(data: any): CartItem[] {

--- a/tests/oda-client.test.ts
+++ b/tests/oda-client.test.ts
@@ -755,3 +755,78 @@ describe("OdaClient frequent products request volume", () => {
     expect(maxInFlight).toBeLessThanOrEqual(5);
   });
 });
+
+describe("OdaClient cart fetch errors", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("rejects with an auth hint when fetching the cart fails with 401", async () => {
+    const json = vi.fn();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(apiResponse(401, json, "not authenticated")),
+    );
+    const client = new OdaClient("/nonexistent/cookies.json");
+
+    await expect(client.getCartContents()).rejects.toThrow(
+      /Get cart failed: HTTP 401 \(authentication may be required or expired\).*not authenticated/,
+    );
+    expect(json).not.toHaveBeenCalled();
+  });
+
+  it("rejects when the cart response is not parseable JSON", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        apiResponse(
+          200,
+          vi.fn().mockRejectedValue(new SyntaxError("Unexpected token <")),
+        ),
+      ),
+    );
+    const client = new OdaClient("/nonexistent/cookies.json");
+
+    await expect(client.getCartContents()).rejects.toThrow(
+      /Get cart failed: unparseable response/,
+    );
+  });
+
+  it("returns the parsed items for a successful cart response", async () => {
+    const cart = {
+      items: [
+        {
+          quantity: 2,
+          product: {
+            id: 42,
+            full_name: "Tine Lettmelk",
+            name_extra: "1,75 l",
+            gross_price: "31.90",
+            gross_unit_price: "18.23",
+            unit_price_quantity_abbreviation: "l",
+          },
+        },
+      ],
+    };
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn()
+        .mockResolvedValue(apiResponse(200, vi.fn().mockResolvedValue(cart))),
+    );
+    const client = new OdaClient("/nonexistent/cookies.json");
+
+    const items = await client.getCartContents();
+    expect(items).toEqual([
+      {
+        id: 42,
+        name: "Tine Lettmelk",
+        subtitle: "1,75 l",
+        quantity: 2,
+        price: 31.9,
+        relative_price: 18.23,
+        relative_price_unit: "/l",
+      },
+    ]);
+  });
+});


### PR DESCRIPTION
`getCartContents` swallowed every failure: a non-2xx response (e.g. an expired session) and an unparseable body both returned `[]`, making an auth failure indistinguishable from a genuinely empty cart.

Now a non-2xx raises via `throwApiError` (which already carries the 401/403 "authentication may be required or expired" hint), and a parse failure throws instead of logging and returning `[]`.

Adds three unit tests: 401 → rejects with the auth hint, unparseable JSON → rejects, valid cart → parsed items.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U2e2Skyds2xUeDGsyUk8DS