### PR TITLE
fix: persist refreshed session cookies to disk

### DIFF
--- a/src/oda-client.ts
+++ b/src/oda-client.ts
@@ -334,14 +334,24 @@ export class OdaClient {
 
   private updateCookies(response: Response) {
     const setCookies = response.headers.getSetCookie();
+    let changed = false;
     for (const header of setCookies) {
       const parts = header.split(";")[0];
       const eq = parts.indexOf("=");
       if (eq > 0) {
         const name = parts.substring(0, eq).trim();
         const value = parts.substring(eq + 1).trim();
-        this.cookies[name] = value;
+        if (this.cookies[name] !== value) {
+          this.cookies[name] = value;
+          changed = true;
+        }
       }
+    }
+    // Persist refreshed session cookies so they outlive this process, but
+    // only into an existing cookie file - an anonymous client (no login,
+    // no file) should never leave a cookie file behind.
+    if (changed && fs.existsSync(this.cookiePath)) {
+      this.saveCookies();
     }
   }
 

--- a/tests/oda-client.test.ts
+++ b/tests/oda-client.test.ts
@@ -755,3 +755,83 @@ describe("OdaClient frequent products request volume", () => {
     expect(maxInFlight).toBeLessThanOrEqual(5);
   });
 });
+
+describe("OdaClient session cookie persistence", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  const responseWithCookies = (cookies: string[]) => ({
+    ok: true,
+    status: 200,
+    headers: { getSetCookie: () => cookies },
+    json: vi.fn().mockResolvedValue({ items: [] }),
+    text: vi.fn().mockResolvedValue(""),
+  });
+
+  it("persists refreshed cookies to an existing cookie file", async () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "mcp-oda-cookie-"));
+    const cookiePath = path.join(tempDir, "cookies.json");
+    fs.writeFileSync(cookiePath, JSON.stringify({ sessionid: "old" }), {
+      mode: 0o600,
+    });
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn()
+        .mockResolvedValue(
+          responseWithCookies(["sessionid=new; Path=/; HttpOnly"]),
+        ),
+    );
+
+    try {
+      const client = new OdaClient(cookiePath);
+      await client.getCartContents();
+      const saved = JSON.parse(fs.readFileSync(cookiePath, "utf-8"));
+      expect(saved.sessionid).toBe("new");
+      expect(fs.statSync(cookiePath).mode & 0o777).toBe(0o600);
+    } finally {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("leaves the cookie file untouched when Set-Cookie changes nothing", async () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "mcp-oda-cookie-"));
+    const cookiePath = path.join(tempDir, "cookies.json");
+    fs.writeFileSync(cookiePath, JSON.stringify({ sessionid: "same" }), {
+      mode: 0o600,
+    });
+    const before = fs.statSync(cookiePath).mtimeMs;
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn()
+        .mockResolvedValue(responseWithCookies(["sessionid=same; Path=/"])),
+    );
+
+    try {
+      const client = new OdaClient(cookiePath);
+      await client.getCartContents();
+      expect(fs.statSync(cookiePath).mtimeMs).toBe(before);
+    } finally {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("does not create a cookie file for an anonymous client", async () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "mcp-oda-cookie-"));
+    const cookiePath = path.join(tempDir, "cookies.json");
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(responseWithCookies(["sessionid=anon"])),
+    );
+
+    try {
+      const client = new OdaClient(cookiePath);
+      await client.getCartContents();
+      expect(fs.existsSync(cookiePath)).toBe(false);
+    } finally {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
Session cookies rotated by ordinary API responses only lived in memory: `saveCookies()` ran solely during `login()`, so every other process exit discarded the refreshed session and shortened its effective lifetime.

`updateCookies` now saves after any response that actually changes a cookie — but only into an existing cookie file, so an anonymous client (search without login) never leaves a cookie file behind.

Adds three unit tests: refreshed cookie persisted with mode 0600, no-op Set-Cookie leaves the file untouched, anonymous client creates no file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U2e2Skyds2xUeDGsyUk8DS