### PR TITLE
fix: distinguish bad credentials from server errors on login, tighten MCP input schemas

### DIFF
--- a/src/oda-client.ts
+++ b/src/oda-client.ts
@@ -1064,7 +1064,14 @@ export class OdaClient {
       return true;
     }
 
-    return false;
+    // Only credential-type rejections mean "wrong username/password"; a 5xx
+    // or anything unexpected is a server problem and must not be reported as
+    // bad credentials.
+    if ([400, 401, 403].includes(response.status)) {
+      return false;
+    }
+    await this.throwApiError("Login", response);
+    return false; // unreachable, throwApiError always throws
   }
 
   async checkUser(): Promise<string | null> {

--- a/src/server.ts
+++ b/src/server.ts
@@ -149,7 +149,7 @@ export class OdaServer {
         inputSchema: {
           list_id: z.number().int().positive(),
           product_id: z.number().int().positive(),
-          quantity: z.number().positive().default(1),
+          quantity: z.number().int().positive().default(1),
           confirmation: z
             .literal("UPDATE SAVED LIST")
             .describe(
@@ -240,7 +240,10 @@ export class OdaServer {
       "cart_remove_item",
       {
         description: "Remove a product from the cart by product ID.",
-        inputSchema: { id: z.number(), count: z.number().optional() },
+        inputSchema: {
+          id: z.number().int().positive(),
+          count: z.number().int().positive().optional(),
+        },
       },
       this.toolHandler("cart_remove_item", async ({ id, count }) => {
         await this.getClient().removeFromCart(id, count);
@@ -252,7 +255,10 @@ export class OdaServer {
       "products_search",
       {
         description: "Search for products on Oda.",
-        inputSchema: { query: z.string(), page: z.number().optional() },
+        inputSchema: {
+          query: z.string(),
+          page: z.number().int().positive().optional(),
+        },
       },
       this.toolHandler("products_search", async ({ query, page }) => {
         return this.jsonResult(
@@ -265,7 +271,10 @@ export class OdaServer {
       "product_add_to_cart",
       {
         description: "Add a product to the cart by product ID.",
-        inputSchema: { id: z.number(), count: z.number().optional() },
+        inputSchema: {
+          id: z.number().int().positive(),
+          count: z.number().int().positive().optional(),
+        },
       },
       this.toolHandler("product_add_to_cart", async ({ id, count }) => {
         await this.getClient().addToCart(id, count);
@@ -279,7 +288,7 @@ export class OdaServer {
         description: "Search for recipes on Oda.",
         inputSchema: {
           query: z.string().optional(),
-          page: z.number().optional(),
+          page: z.number().int().positive().optional(),
           filter_ids: z.array(z.string()).optional(),
         },
       },
@@ -297,7 +306,7 @@ export class OdaServer {
       "recipes_get_details",
       {
         description: "Get recipe details by recipe ID.",
-        inputSchema: { id: z.number() },
+        inputSchema: { id: z.number().int().positive() },
       },
       this.toolHandler("recipes_get_details", async ({ id }) => {
         return this.jsonResult(await this.getClient().getRecipeDetails(id));
@@ -308,7 +317,10 @@ export class OdaServer {
       "recipe_add_to_cart",
       {
         description: "Add recipe ingredients to cart by recipe ID.",
-        inputSchema: { id: z.number(), portions: z.number() },
+        inputSchema: {
+          id: z.number().int().positive(),
+          portions: z.number().int().positive(),
+        },
       },
       this.toolHandler("recipe_add_to_cart", async ({ id, portions }) => {
         await this.getClient().addRecipeToCart(id, portions);
@@ -321,7 +333,7 @@ export class OdaServer {
       {
         description:
           "Remove a recipe and its ingredients from the cart by recipe ID.",
-        inputSchema: { id: z.number() },
+        inputSchema: { id: z.number().int().positive() },
       },
       this.toolHandler("recipe_remove_from_cart", async ({ id }) => {
         await this.getClient().removeRecipeFromCart(id);

--- a/tests/oda-client.test.ts
+++ b/tests/oda-client.test.ts
@@ -755,3 +755,47 @@ describe("OdaClient frequent products request volume", () => {
     expect(maxInFlight).toBeLessThanOrEqual(5);
   });
 });
+
+describe("OdaClient login error classification", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  const loginPage = () => ({
+    ok: true,
+    status: 200,
+    headers: { getSetCookie: () => ["csrftoken=tok; Path=/"] },
+    json: vi.fn(),
+    text: vi.fn().mockResolvedValue("<html></html>"),
+  });
+
+  it("returns false for rejected credentials", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn()
+        .mockResolvedValueOnce(loginPage())
+        .mockResolvedValueOnce(apiResponse(401, vi.fn(), "bad credentials")),
+    );
+    const client = new OdaClient("/nonexistent/cookies.json");
+
+    await expect(client.login("user@example.com", "wrong")).resolves.toBe(
+      false,
+    );
+  });
+
+  it("throws on a server error instead of reporting bad credentials", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn()
+        .mockResolvedValueOnce(loginPage())
+        .mockResolvedValueOnce(apiResponse(500, vi.fn(), "boom")),
+    );
+    const client = new OdaClient("/nonexistent/cookies.json");
+
+    await expect(client.login("user@example.com", "pw")).rejects.toThrow(
+      /Login failed: HTTP 500.*boom/,
+    );
+  });
+});


### PR DESCRIPTION
Two small fixes:

- `login()` returned a bare `false` for every non-2xx response, so a wrong password and a 500 were indistinguishable. Only 400/401/403 now mean rejected credentials; anything else raises through `throwApiError`.
- The MCP tools were inconsistent about numeric validation: saved-list IDs used `z.number().int().positive()` while cart/product/recipe IDs, counts, pages and portions used bare `z.number()`. Now aligned.

Adds two login unit tests (401 → `false`, 500 → throws).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U2e2Skyds2xUeDGsyUk8DS