### PR TITLE
feat: configurable cart recommendations with in-cart filtering

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -244,9 +244,15 @@ cartCmd
 cartCmd
   .command("recommendations")
   .description("Show Oda's current cart recommendations")
-  .action(async () => {
+  .option("--limit <number>", "Maximum number of recommendations", "20")
+  .option("--exclude-in-cart", "Hide products already in the cart")
+  .action(async (cmdOpts) => {
     const client = makeClient();
-    console.log(JSON.stringify(await client.getCartRecommendations(), null, 2));
+    const recommendations = await client.getCartRecommendations({
+      limit: parseInt(cmdOpts.limit),
+      excludeInCart: cmdOpts.excludeInCart === true,
+    });
+    console.log(JSON.stringify(recommendations, null, 2));
   });
 
 // --- recipe commands ---

--- a/src/oda-client.ts
+++ b/src/oda-client.ts
@@ -641,14 +641,27 @@ export class OdaClient {
       .slice(0, limit);
   }
 
-  async getCartRecommendations(): Promise<CartRecommendation[]> {
+  async getCartRecommendations(options?: {
+    limit?: number;
+    excludeInCart?: boolean;
+  }): Promise<CartRecommendation[]> {
     const response = await this.apiGet(
       `${OdaClient.API_BASE}/api/v1/cart/recommendations/`,
     );
     if (!response.ok) {
       await this.throwApiError("Get cart recommendations", response);
     }
-    return OdaClient.collectRecommendedProducts(await response.json());
+    let recommendations = OdaClient.collectRecommendedProducts(
+      await response.json(),
+      options?.limit,
+    );
+    if (options?.excludeInCart) {
+      // Oda recommends items already in the cart; those are rarely useful.
+      const cart = await this.getCartContents();
+      const inCart = new Set(cart.items.map((item) => item.id));
+      recommendations = recommendations.filter((r) => !inCart.has(r.id));
+    }
+    return recommendations;
   }
 
   /**

--- a/src/oda-client.ts
+++ b/src/oda-client.ts
@@ -838,16 +838,17 @@ export class OdaClient {
       throw new Error("Server returned 425 Too Early. Please try again later.");
     }
     if (!response.ok) {
-      return [];
+      // An expired session must not look like an empty cart
+      await this.throwApiError("Get cart", response);
     }
 
+    let data: any;
     try {
-      const data = await response.json();
-      return this.parseCartApi(data);
+      data = await response.json();
     } catch (e) {
-      console.error("Failed to parse cart API response", e);
-      return [];
+      throw new Error(`Get cart failed: unparseable response (${e})`);
     }
+    return this.parseCartApi(data);
   }
 
   private parseCartApi(data: any): CartItem[] {

--- a/src/oda-client.ts
+++ b/src/oda-client.ts
@@ -1,7 +1,8 @@
 import {
   SearchResult,
   ProductPage,
-  CartItem,
+  Cart,
+  CartLine,
   Recipe,
   RecipeFilter,
   RecipePage,
@@ -831,7 +832,7 @@ export class OdaClient {
     }
   }
 
-  async getCartContents(): Promise<CartItem[]> {
+  async getCartContents(): Promise<Cart> {
     // Cart data is not in __NEXT_DATA__, use the REST API directly
     const response = await this.apiGet(OdaClient.CART_API);
     if (response.status === 425) {
@@ -851,16 +852,21 @@ export class OdaClient {
     return this.parseCartApi(data);
   }
 
-  private parseCartApi(data: any): CartItem[] {
-    const items: CartItem[] = [];
+  private parseCartApi(data: any): Cart {
+    const items: CartLine[] = [];
 
-    // Items can be at top-level or nested under groups
-    const rawItems: any[] = data.items || [];
+    // Items can be at top-level or nested under groups (e.g. recipes). The
+    // list stays flat; group membership is annotated per line instead.
+    const rawItems: Array<{ item: any; group?: any }> = (data.items || []).map(
+      (item: any) => ({ item }),
+    );
     for (const group of data.groups || []) {
-      rawItems.push(...(group.items || []));
+      for (const item of group.items || []) {
+        rawItems.push({ item, group });
+      }
     }
 
-    for (const item of rawItems) {
+    for (const { item, group } of rawItems) {
       const product = item.product || {};
       const productId = product.id;
       const name = product.full_name || product.name || "Unknown Product";
@@ -870,7 +876,7 @@ export class OdaClient {
       const unitPrice = parseFloat(product.gross_unit_price) || 0;
       const unitPriceUnit = product.unit_price_quantity_abbreviation || "";
 
-      items.push({
+      const line: CartLine = {
         id: productId,
         name,
         subtitle,
@@ -878,10 +884,21 @@ export class OdaClient {
         price,
         relative_price: unitPrice,
         relative_price_unit: unitPriceUnit ? `/${unitPriceUnit}` : "",
-      });
+        item_id: item.item_id || 0,
+        line_total: parseFloat(item.display_price_total) || price * quantity,
+      };
+      if (group?.title) line.group_title = group.title;
+      if (group?.group_type) line.group_type = group.group_type;
+      items.push(line);
     }
 
-    return items;
+    return {
+      label_text: data.label_text || "",
+      product_quantity_count: data.product_quantity_count || 0,
+      display_price: parseFloat(data.display_price) || 0,
+      total_gross_amount: parseFloat(data.total_gross_amount) || 0,
+      items,
+    };
   }
 
   async addToCart(productId: number, count = 1): Promise<void> {

--- a/src/server.ts
+++ b/src/server.ts
@@ -80,7 +80,8 @@ export class OdaServer {
     this.mcpServer.registerTool(
       "cart_get_contents",
       {
-        description: "Get the current shopping cart contents.",
+        description:
+          "Get the current shopping cart: totals (display_price, item count) and items, with recipe grouping annotated per line.",
       },
       this.toolHandler("cart_get_contents", async () => {
         return this.jsonResult(await this.getClient().getCartContents());

--- a/src/server.ts
+++ b/src/server.ts
@@ -113,10 +113,22 @@ export class OdaServer {
       {
         description:
           "Read Oda's current cart recommendations as a normalized product list. Read-only; recommendations may be empty when the cart is empty.",
+        inputSchema: {
+          limit: z.number().int().min(1).max(50).optional(),
+          exclude_in_cart: z.boolean().optional(),
+        },
       },
-      this.toolHandler("cart_get_recommendations", async () => {
-        return this.jsonResult(await this.getClient().getCartRecommendations());
-      }),
+      this.toolHandler(
+        "cart_get_recommendations",
+        async ({ limit, exclude_in_cart }) => {
+          return this.jsonResult(
+            await this.getClient().getCartRecommendations({
+              limit,
+              excludeInCart: exclude_in_cart,
+            }),
+          );
+        },
+      ),
     );
 
     this.mcpServer.registerTool(

--- a/src/types.ts
+++ b/src/types.ts
@@ -23,6 +23,26 @@ export interface CartItem {
   relative_price_unit: string;
 }
 
+export interface CartLine extends CartItem {
+  /** Cart line id, distinct from the product id. */
+  item_id: number;
+  /** Total price for the line (quantity x price, weight-adjusted by Oda). */
+  line_total: number;
+  /** Group heading (e.g. a recipe name) when the item belongs to a group. */
+  group_title?: string;
+  group_type?: string;
+}
+
+export interface Cart {
+  /** Human-readable cart label, e.g. "30 varer". */
+  label_text: string;
+  product_quantity_count: number;
+  /** What the cart costs at current prices. */
+  display_price: number;
+  total_gross_amount: number;
+  items: CartLine[];
+}
+
 export interface Recipe {
   id: number;
   name: string;

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -115,14 +115,18 @@ describe("Oda Integration Tests", () => {
 
       // Verify product is in cart
       const cartAfterAdd = await authClient.getCartContents();
-      expect(cartAfterAdd.some((item) => item.id === productId)).toBe(true);
+      expect(cartAfterAdd.items.some((item) => item.id === productId)).toBe(
+        true,
+      );
 
       // Remove from cart (throws on failure)
       await authClient.removeFromCart(productId);
 
       // Verify product is no longer in cart
       const cartAfterRemove = await authClient.getCartContents();
-      expect(cartAfterRemove.some((item) => item.id === productId)).toBe(false);
+      expect(cartAfterRemove.items.some((item) => item.id === productId)).toBe(
+        false,
+      );
     }, 60000);
 
     it("should clear the cart", async () => {
@@ -134,14 +138,14 @@ describe("Oda Integration Tests", () => {
 
       // Verify cart is non-empty
       const cartBefore = await authClient.getCartContents();
-      expect(cartBefore.length).toBeGreaterThan(0);
+      expect(cartBefore.items.length).toBeGreaterThan(0);
 
       // Clear cart (throws on failure)
       await authClient.clearCart();
 
       // Verify cart is empty
       const cartAfter = await authClient.getCartContents();
-      expect(cartAfter.length).toBe(0);
+      expect(cartAfter.items.length).toBe(0);
     }, 60000);
 
     it("should add and remove a recipe from cart", async () => {
@@ -153,7 +157,7 @@ describe("Oda Integration Tests", () => {
 
       // Verify cart has items from the recipe
       const cartAfterAdd = await authClient.getCartContents();
-      expect(cartAfterAdd.length).toBeGreaterThan(0);
+      expect(cartAfterAdd.items.length).toBeGreaterThan(0);
 
       // Remove recipe from cart
       await authClient.removeRecipeFromCart(recipeId);

--- a/tests/oda-client.test.ts
+++ b/tests/oda-client.test.ts
@@ -914,3 +914,74 @@ describe("OdaClient cart totals and grouping", () => {
     expect(avocado.group_type).toBe("recipe");
   });
 });
+
+describe("OdaClient cart recommendation options", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  const recommendationPayload = {
+    groups: [
+      {
+        items: [
+          { id: 1, full_name: "Vare A", gross_price: "10.00" },
+          { id: 2, full_name: "Vare B", gross_price: "20.00" },
+          { id: 3, full_name: "Vare C", gross_price: "30.00" },
+        ],
+      },
+    ],
+  };
+
+  it("respects the limit while walking the payload", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn()
+        .mockResolvedValue(
+          apiResponse(
+            200,
+            vi.fn().mockResolvedValue(recommendationPayload),
+          ),
+        ),
+    );
+    const client = new OdaClient("/nonexistent/cookies.json");
+
+    const recs = await client.getCartRecommendations({ limit: 2 });
+    expect(recs).toHaveLength(2);
+  });
+
+  it("filters out products already in the cart", async () => {
+    const cartResponse = {
+      label_text: "1 vare",
+      product_quantity_count: 1,
+      display_price: "10.00",
+      total_gross_amount: "10.00",
+      items: [
+        {
+          item_id: 5,
+          quantity: 1,
+          display_price_total: "10.00",
+          product: { id: 2, full_name: "Vare B", gross_price: "20.00" },
+        },
+      ],
+    };
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn()
+        .mockResolvedValueOnce(
+          apiResponse(
+            200,
+            vi.fn().mockResolvedValue(recommendationPayload),
+          ),
+        )
+        .mockResolvedValueOnce(
+          apiResponse(200, vi.fn().mockResolvedValue(cartResponse)),
+        ),
+    );
+    const client = new OdaClient("/nonexistent/cookies.json");
+
+    const recs = await client.getCartRecommendations({ excludeInCart: true });
+    expect(recs.map((r) => r.id)).toEqual([1, 3]);
+  });
+});

--- a/tests/oda-client.test.ts
+++ b/tests/oda-client.test.ts
@@ -755,3 +755,78 @@ describe("OdaClient frequent products request volume", () => {
     expect(maxInFlight).toBeLessThanOrEqual(5);
   });
 });
+
+describe("OdaClient cart fetch errors", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("rejects with an auth hint when fetching the cart fails with 401", async () => {
+    const json = vi.fn();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(apiResponse(401, json, "not authenticated")),
+    );
+    const client = new OdaClient("/nonexistent/cookies.json");
+
+    await expect(client.getCartContents()).rejects.toThrow(
+      /Get cart failed: HTTP 401 \(authentication may be required or expired\).*not authenticated/,
+    );
+    expect(json).not.toHaveBeenCalled();
+  });
+
+  it("rejects when the cart response is not parseable JSON", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        apiResponse(
+          200,
+          vi.fn().mockRejectedValue(new SyntaxError("Unexpected token <")),
+        ),
+      ),
+    );
+    const client = new OdaClient("/nonexistent/cookies.json");
+
+    await expect(client.getCartContents()).rejects.toThrow(
+      /Get cart failed: unparseable response/,
+    );
+  });
+
+  it("returns the parsed items for a successful cart response", async () => {
+    const cart = {
+      items: [
+        {
+          quantity: 2,
+          product: {
+            id: 42,
+            full_name: "Tine Lettmelk",
+            name_extra: "1,75 l",
+            gross_price: "31.90",
+            gross_unit_price: "18.23",
+            unit_price_quantity_abbreviation: "l",
+          },
+        },
+      ],
+    };
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn()
+        .mockResolvedValue(apiResponse(200, vi.fn().mockResolvedValue(cart))),
+    );
+    const client = new OdaClient("/nonexistent/cookies.json");
+
+    const items = await client.getCartContents();
+    expect(items).toEqual([
+      {
+        id: 42,
+        name: "Tine Lettmelk",
+        subtitle: "1,75 l",
+        quantity: 2,
+        price: 31.9,
+        relative_price: 18.23,
+        relative_price_unit: "/l",
+      },
+    ]);
+  });
+});

--- a/tests/oda-client.test.ts
+++ b/tests/oda-client.test.ts
@@ -816,8 +816,8 @@ describe("OdaClient cart fetch errors", () => {
     );
     const client = new OdaClient("/nonexistent/cookies.json");
 
-    const items = await client.getCartContents();
-    expect(items).toEqual([
+    const result = await client.getCartContents();
+    expect(result.items).toEqual([
       {
         id: 42,
         name: "Tine Lettmelk",
@@ -826,7 +826,91 @@ describe("OdaClient cart fetch errors", () => {
         price: 31.9,
         relative_price: 18.23,
         relative_price_unit: "/l",
+        item_id: 0,
+        line_total: 63.8,
       },
     ]);
+  });
+});
+
+describe("OdaClient cart totals and grouping", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("keeps cart totals and annotates group membership per line", async () => {
+    // Mirrors the documented GET /api/v1/cart/ response (ODA_API.md)
+    const cartResponse = {
+      id: 0,
+      label_text: "3 varer",
+      product_quantity_count: 3,
+      display_price: "1068.40",
+      total_gross_amount: "1116.29",
+      items: [
+        {
+          item_id: 111,
+          quantity: 2,
+          display_price_total: "63.80",
+          product: {
+            id: 42,
+            full_name: "Tine Lettmelk",
+            name_extra: "1,75 l",
+            gross_price: "31.90",
+            gross_unit_price: "18.23",
+            unit_price_quantity_abbreviation: "l",
+          },
+        },
+      ],
+      groups: [
+        {
+          id: "recipe-1",
+          title: "Pizza Margherita",
+          group_type: "recipe",
+          items: [
+            {
+              item_id: 222,
+              quantity: 1,
+              display_price_total: "29.90",
+              product: {
+                id: 9452,
+                full_name: "Avokado modnet Chile / Spania/ Marokko",
+                name: "Avokado modnet",
+                name_extra: "Chile / Spania/ Marokko, 2 stk",
+                gross_price: "29.90",
+                gross_unit_price: "14.95",
+                unit_price_quantity_abbreviation: "stk",
+              },
+            },
+          ],
+        },
+      ],
+    };
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn()
+        .mockResolvedValue(
+          apiResponse(200, vi.fn().mockResolvedValue(cartResponse)),
+        ),
+    );
+    const client = new OdaClient("/nonexistent/cookies.json");
+
+    const cart = await client.getCartContents();
+    expect(cart.label_text).toBe("3 varer");
+    expect(cart.product_quantity_count).toBe(3);
+    expect(cart.display_price).toBe(1068.4);
+    expect(cart.total_gross_amount).toBe(1116.29);
+    expect(cart.items).toHaveLength(2);
+
+    const [milk, avocado] = cart.items;
+    expect(milk.item_id).toBe(111);
+    expect(milk.line_total).toBe(63.8);
+    expect(milk.group_title).toBeUndefined();
+
+    expect(avocado.id).toBe(9452);
+    expect(avocado.item_id).toBe(222);
+    expect(avocado.line_total).toBe(29.9);
+    expect(avocado.group_title).toBe("Pizza Margherita");
+    expect(avocado.group_type).toBe("recipe");
   });
 });


### PR DESCRIPTION
Stacked on #156 (draft until it lands; uses the Cart type for the in-cart filter).

The recommendation walk was capped at a hardcoded 20 items, and Oda routinely recommends products already in the cart. `getCartRecommendations({limit, excludeInCart})`: limit is threaded into the payload walk, excludeInCart drops recommended ids already present as cart lines.

- CLI: `cart recommendations --limit <n> --exclude-in-cart`
- MCP: `cart_get_recommendations {limit?, exclude_in_cart?}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U2e2Skyds2xUeDGsyUk8DS