### PR TITLE
feat: expose ingredient-to-product mapping in recipe details

### DIFF
--- a/src/oda-client.ts
+++ b/src/oda-client.ts
@@ -6,6 +6,7 @@ import {
   RecipeFilter,
   RecipePage,
   RecipeDetail,
+  RecipeIngredient,
   SavedList,
   SavedListDetail,
   SavedListItem,
@@ -1002,18 +1003,47 @@ export class OdaClient {
       },
     );
 
+    // Structured ingredients with the product mapping addRecipeToCart uses,
+    // so callers can see what a recipe would put in the cart without adding
+    // it. data.ingredients[] carries the product link; join it with the
+    // display list by index when the lists line up, else fall back to the
+    // ingredient's own display fields.
+    const rawIngredients: any[] = data.ingredients || [];
+    const displayList: any[] = data.ingredientsDisplayList || [];
+    const ingredientItems = rawIngredients.map((ing: any, i: number) => {
+      const display = displayList[i] || {};
+      const item: RecipeIngredient = {
+        title: display.title || ing.product?.full_name || ing.title || "",
+        quantity:
+          parseFloat(display.displayQuantity ?? ing.displayQuantity) || 0,
+        unit: display.displayUnit ?? ing.displayUnit ?? "",
+      };
+      if (ing.product?.id) {
+        item.product_id = ing.product.id;
+        const portionQuantity = parseFloat(ing.portionQuantity);
+        if (Number.isFinite(portionQuantity)) {
+          item.portion_quantity = portionQuantity;
+        }
+      }
+      return item;
+    });
+
     // Instructions
     const instructions: string[] = (data.instructions?.instructions || []).map(
       (step: any) => step.text || "",
     );
 
-    return {
+    const detail: RecipeDetail = {
       name,
       description,
       ingredients,
       instructions,
       image_url: imageUrl,
     };
+    if (ingredientItems.length > 0) {
+      detail.ingredient_items = ingredientItems;
+    }
+    return detail;
   }
 
   async addRecipeToCart(recipeId: number, portions: number): Promise<void> {

--- a/src/types.ts
+++ b/src/types.ts
@@ -45,10 +45,25 @@ export interface RecipePage {
   has_more: boolean;
 }
 
+export interface RecipeIngredient {
+  title: string;
+  quantity: number;
+  unit: string;
+  /** Purchasable product behind the ingredient, when Oda maps one. */
+  product_id?: number;
+  /** Cart quantity per portion, as used when adding the recipe to the cart. */
+  portion_quantity?: number;
+}
+
 export interface RecipeDetail {
   name: string;
   description: string;
   ingredients: string[];
+  /**
+   * Structured ingredients with product mapping. Absent when the recipe was
+   * loaded from the JSON-LD fallback, which carries no product IDs.
+   */
+  ingredient_items?: RecipeIngredient[];
   instructions: string[];
   image_url?: string;
 }

--- a/tests/oda-client.test.ts
+++ b/tests/oda-client.test.ts
@@ -755,3 +755,66 @@ describe("OdaClient frequent products request volume", () => {
     expect(maxInFlight).toBeLessThanOrEqual(5);
   });
 });
+
+describe("OdaClient recipe ingredient mapping", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  const recipeData = {
+    title: "Pizza Margherita",
+    lead: "Klassisk pizza",
+    ingredientsDisplayList: [
+      { title: "Mozzarella, fersk", displayQuantity: "250", displayUnit: "g" },
+      { title: "Basilikum", displayQuantity: "1", displayUnit: "pott" },
+    ],
+    ingredients: [
+      {
+        product: { id: 4321, full_name: "Mozzarella" },
+        portionQuantity: "0.5",
+      },
+      {},
+    ],
+    instructions: { instructions: [{ text: "Stek pizzaen" }] },
+  };
+
+  const hydrationHtml = () => {
+    const queries = [
+      { queryKey: [{ _id: "recipeDetailApi" }], state: { data: recipeData } },
+    ];
+    return `<html><script>self.__next_f.push([1,${JSON.stringify(
+      `"queries":${JSON.stringify(queries)}`,
+    )}])</script></html>`;
+  };
+
+  it("exposes structured ingredients with product mapping", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        headers: { getSetCookie: () => [], get: () => "text/html" },
+        json: vi.fn(),
+        text: vi.fn().mockResolvedValue(hydrationHtml()),
+      }),
+    );
+    const client = new OdaClient("/nonexistent/cookies.json");
+
+    const detail = await client.getRecipeDetails(1);
+    expect(detail.name).toBe("Pizza Margherita");
+    expect(detail.ingredients).toEqual([
+      "250 g Mozzarella, fersk",
+      "1 pott Basilikum",
+    ]);
+    expect(detail.ingredient_items).toEqual([
+      {
+        title: "Mozzarella, fersk",
+        quantity: 250,
+        unit: "g",
+        product_id: 4321,
+        portion_quantity: 0.5,
+      },
+      { title: "Basilikum", quantity: 1, unit: "pott" },
+    ]);
+  });
+});


### PR DESCRIPTION
Additive: `RecipeDetail` keeps `ingredients: string[]` and gains `ingredient_items` — structured `{title, quantity, unit, product_id?, portion_quantity?}` entries joined from `ingredientsDisplayList` and the product-linked `ingredients[]` array that `addRecipeToCart` already reads. Callers can now see what a recipe would put in the cart (and which ingredients have no purchasable product) without adding it.

Omitted on the JSON-LD fallback path, which carries no product IDs — documented on the type.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U2e2Skyds2xUeDGsyUk8DS