### PR TITLE
feat(dump): print raw JSON bodies for API endpoints

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -342,7 +342,7 @@ program
 // --- dump command (unchanged) ---
 program
   .command("dump <url>")
-  .description("Fetch a URL and print its hydration data")
+  .description("Fetch a URL and print its hydration data or JSON body")
   .action(async (url: string) => {
     const client = makeClient();
 
@@ -365,12 +365,17 @@ program
           : "(none found)",
       );
 
-      console.log(`\n=== Hydration data ===`);
-      console.log(
-        result.nextData
-          ? JSON.stringify(result.nextData, null, 2)
-          : "(not found)",
-      );
+      if (result.jsonBody !== null) {
+        console.log(`\n=== JSON body ===`);
+        console.log(JSON.stringify(result.jsonBody, null, 2));
+      } else {
+        console.log(`\n=== Hydration data ===`);
+        console.log(
+          result.nextData
+            ? JSON.stringify(result.nextData, null, 2)
+            : "(not found)",
+        );
+      }
     } catch (e) {
       console.error("Dump failed:", e);
       process.exit(1);

--- a/src/oda-client.ts
+++ b/src/oda-client.ts
@@ -498,25 +498,39 @@ export class OdaClient {
 
   async dump(url: string): Promise<{
     nextData: any | null;
+    jsonBody: any | null;
     queryKeys: string[];
     headers: Record<string, string>;
     status: number;
     finalUrl: string;
   }> {
     const response = await this.getFollowRedirects(url);
-    const html = await response.text();
+    const body = await response.text();
 
     const responseHeaders: Record<string, string> = {};
     response.headers.forEach((value, key) => {
       responseHeaders[key] = value;
     });
 
-    const nextData = extractNextData(html);
+    // JSON API endpoints have no hydration payload - surface the raw body
+    // instead so dump works for API discovery too.
+    let jsonBody: any | null = null;
+    const contentType = response.headers.get("content-type") || "";
+    if (contentType.includes("application/json")) {
+      try {
+        jsonBody = JSON.parse(body);
+      } catch {
+        // fall through with jsonBody = null
+      }
+    }
+
+    const nextData = jsonBody === null ? extractNextData(body) : null;
     const queries: any[] =
       nextData?.props?.pageProps?.dehydratedState?.queries ?? [];
 
     return {
       nextData,
+      jsonBody,
       queryKeys: queries.map((q) => describeQueryKey(q.queryKey)),
       headers: responseHeaders,
       status: response.status,


### PR DESCRIPTION
`dump` only surfaced HTML hydration payloads, so pointing it at a JSON API endpoint printed `(not found)` and hid the response. When the content-type is `application/json`, parse and print the body under a `=== JSON body ===` section instead — making `dump` usable for API discovery, not just page-structure discovery.

Verified live against `GET /api/v1/cart/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U2e2Skyds2xUeDGsyUk8DS