### PR TITLE
feat: enrich product search results with availability, discounts and filters

### DIFF
--- a/src/oda-client.ts
+++ b/src/oda-client.ts
@@ -181,43 +181,11 @@ function requireSearchData(
   return data;
 }
 
-export function parseProductPage(url: string, nextData: any): ProductPage {
-  const data = requireSearchData(
-    url,
-    nextData,
-    "product",
-    "searchpageresponse",
-  );
-  const items: SearchResult[] = [];
-
-  for (const item of data.items) {
-    if (item.type !== "product") continue;
-    const a = item.attributes;
-    if (!a) continue;
-
-    const unitPriceUnit = a.unitPriceQuantityAbbreviation || "";
-
-    items.push({
-      id: a.id || item.id,
-      name: a.fullName || a.name || "Unknown",
-      subtitle: a.nameExtra || "",
-      price: parseFloat(a.grossPrice) || 0,
-      relative_price: parseFloat(a.grossUnitPrice) || 0,
-      relative_price_unit: unitPriceUnit ? `/${unitPriceUnit}` : "",
-    });
-  }
-
-  return {
-    page_url: url,
-    items,
-    has_more: data.attributes?.hasMoreItems === true,
-  };
-}
-
-export function parseRecipePage(url: string, nextData: any): RecipePage {
-  const data = requireSearchData(url, nextData, "recipe", "searchresponse");
-
-  // Filters: data.filters[] can be a filtergroup or a flat filter
+/**
+ * Parse the filters block shared by product and recipe search payloads.
+ * Filters arrive either grouped (filtergroup with items) or flat.
+ */
+function parseSearchFilters(data: any): RecipeFilter[] {
   const filters: RecipeFilter[] = [];
   for (const f of data.filters || []) {
     if (f.type === "filtergroup" && f.items) {
@@ -239,6 +207,87 @@ export function parseRecipePage(url: string, nextData: any): RecipePage {
       });
     }
   }
+  return filters;
+}
+
+export function parseProductPage(url: string, nextData: any): ProductPage {
+  const data = requireSearchData(
+    url,
+    nextData,
+    "product",
+    "searchpageresponse",
+  );
+  const items: SearchResult[] = [];
+
+  for (const item of data.items) {
+    if (item.type !== "product") continue;
+    const a = item.attributes;
+    if (!a) continue;
+
+    const unitPriceUnit = a.unitPriceQuantityAbbreviation || "";
+
+    const result: SearchResult = {
+      id: a.id || item.id,
+      name: a.fullName || a.name || "Unknown",
+      subtitle: a.nameExtra || "",
+      price: parseFloat(a.grossPrice) || 0,
+      relative_price: parseFloat(a.grossUnitPrice) || 0,
+      relative_price_unit: unitPriceUnit ? `/${unitPriceUnit}` : "",
+    };
+
+    if (a.brand) result.brand = a.brand;
+    if (a.currency) result.currency = a.currency;
+    if (a.availability) {
+      result.is_available = a.availability.isAvailable === true;
+      if (a.availability.code && a.availability.code !== "available") {
+        result.availability_code = a.availability.code;
+      }
+    }
+    if (a.discount?.isDiscounted) {
+      result.discount = {
+        undiscounted_price: parseFloat(a.discount.undiscountedGrossPrice) || 0,
+      };
+      if (a.discount.descriptionShort) {
+        result.discount.description = a.discount.descriptionShort;
+      }
+      if (a.discount.maximumQuantity) {
+        result.discount.maximum_quantity = a.discount.maximumQuantity;
+      }
+    }
+    const thumbnail = a.images?.[0]?.thumbnail?.url;
+    if (thumbnail) result.image_url = thumbnail;
+
+    items.push(result);
+  }
+
+  const page: ProductPage = {
+    page_url: url,
+    items,
+    has_more: data.attributes?.hasMoreItems === true,
+  };
+
+  const typeCounts: Record<string, number> = {};
+  for (const rt of data.attributes?.requestTypes || []) {
+    if (rt.type && Number.isFinite(rt.count)) {
+      typeCounts[rt.type] = rt.count;
+    }
+  }
+  if (Object.keys(typeCounts).length > 0) {
+    page.type_counts = typeCounts;
+    if (typeCounts["product"] !== undefined) {
+      page.total_count = typeCounts["product"];
+    }
+  }
+  const filters = parseSearchFilters(data);
+  if (filters.length > 0) page.filters = filters;
+
+  return page;
+}
+
+export function parseRecipePage(url: string, nextData: any): RecipePage {
+  const data = requireSearchData(url, nextData, "recipe", "searchresponse");
+
+  const filters = parseSearchFilters(data);
 
   const items: Recipe[] = [];
   for (const item of data.items) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,12 +5,31 @@ export interface SearchResult {
   price: number;
   relative_price: number;
   relative_price_unit: string;
+  brand?: string;
+  currency?: string;
+  is_available?: boolean;
+  /** Only set when the product is not plainly available. */
+  availability_code?: string;
+  discount?: {
+    undiscounted_price: number;
+    description?: string;
+    /** Max units at the discounted price, when the campaign caps it. */
+    maximum_quantity?: number;
+  };
+  image_url?: string;
 }
+
+export type SearchFilter = RecipeFilter;
 
 export interface ProductPage {
   page_url: string;
   items: SearchResult[];
   has_more: boolean;
+  /** Total matching products across all pages. */
+  total_count?: number;
+  /** Matches per content type (product, recipe, ...). */
+  type_counts?: Record<string, number>;
+  filters?: SearchFilter[];
 }
 
 export interface CartItem {

--- a/tests/parse-pages.test.ts
+++ b/tests/parse-pages.test.ts
@@ -41,7 +41,51 @@ describe("parseProductPage", () => {
       id: 8143,
       name: "Tine Lettmelk 1% fett",
       price: 31.9,
+      brand: "TINE",
+      currency: "NOK",
+      is_available: true,
     });
+    expect(page.items[0].image_url).toMatch(/^https:\/\/images\.oda\.com\//);
+    expect(page.total_count).toBe(562);
+    expect(page.type_counts).toMatchObject({ product: 562, recipe: 308 });
+    expect(page.filters?.length).toBeGreaterThan(0);
+  });
+
+  it("parses discount and unavailability details", () => {
+    const page = parseProductPage(
+      URL,
+      hydrated("mixedSearch", {
+        items: [
+          {
+            type: "product",
+            attributes: {
+              id: 1,
+              fullName: "Tilbudsvare",
+              grossPrice: "10.00",
+              availability: { isAvailable: false, code: "sold_out" },
+              discount: {
+                isDiscounted: true,
+                undiscountedGrossPrice: "20.00",
+                descriptionShort: "Salg!",
+                maximumQuantity: 3,
+              },
+            },
+          },
+        ],
+        attributes: {},
+      }),
+    );
+
+    expect(page.items[0]).toMatchObject({
+      is_available: false,
+      availability_code: "sold_out",
+      discount: {
+        undiscounted_price: 20,
+        description: "Salg!",
+        maximum_quantity: 3,
+      },
+    });
+    expect(page.total_count).toBeUndefined();
   });
 
   it("throws when the page has no hydration data", () => {


### PR DESCRIPTION
Additive only — existing fields untouched.

`parseProductPage` kept 6 fields per item and discarded the rest of the hydration payload:

- `SearchResult` gains `brand`, `currency`, `is_available`, `availability_code` (only when not plainly available), `discount {undiscounted_price, description, maximum_quantity}` and `image_url` (thumbnail).
- `ProductPage` gains `total_count`, `type_counts` (matches per content type) and `filters` — product search payloads carry the same filters block recipe search already parsed, so parsing is extracted to a shared `parseSearchFilters` helper used by both.

Verified against live search payloads (including a discounted item for the discount shape); the existing `search-app-router.html` fixture already carries the enriched attributes and the real-page test now asserts them, plus a synthetic discount/sold-out case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U2e2Skyds2xUeDGsyUk8DS