### PR TITLE
feat: read-only delivery slot listing

### DIFF
--- a/ODA_API.md
+++ b/ODA_API.md
@@ -515,6 +515,86 @@ Note its `queryKey` is a plain string array (`["user"]`), not the
 }
 ```
 
+## Delivery Slots
+
+**GET** `https://oda.com/api/v1/slot-picker/slots/`
+
+Requires an authenticated session. Read-only view of the delivery slot picker,
+including per-slot ordering deadlines and validation against the current cart.
+
+**Response** (snake_case, trimmed):
+```json
+{
+  "time_zone": "Europe/Oslo",
+  "from_index": 0,
+  "has_earlier": false,
+  "has_later": true,
+  "has_cheapest": true,
+  "unattended_available": true,
+  "delivery_slots": [
+    {
+      "id": 1646967,
+      "route_group": 1,
+      "route_group_str": "Morning",
+      "open_datetime": "2026-09-04T03:00:00Z",
+      "close_datetime": "2026-09-04T05:00:00Z",
+      "cutoff_time": "2026-09-03T18:00:00Z",
+      "price": "kr 79",
+      "is_selected": false,
+      "is_full": false,
+      "is_unavailable": false,
+      "is_cheapest": false,
+      "unavailable_description": "",
+      "has_discount_neighbor": false,
+      "has_discount_delivery_coupon": false,
+      "tag": null,
+      "validation_messages": []
+    }
+  ],
+  "cart_info": {
+    "delivery_slot": null,
+    "delivery_address": { "id": 0, "address_display_full": "..." }
+  },
+  "delivery_addresses": [],
+  "validation_messages": [
+    {
+      "type": "product_availability_date",
+      "description": "Noen av varene i handlekurven ... er ikke tilgjengelige før ..."
+    }
+  ]
+}
+```
+
+Notes:
+
+- `cutoff_time` is the ordering deadline for the slot.
+- `price` is a display string (`"kr 79"`, with a non-breaking space), not a
+  number.
+- `is_unavailable` + `unavailable_description` reflect the **current cart**:
+  a slot can be unavailable because a cart item is not purchasable until a
+  later date. Top-level `validation_messages` carries the same warnings.
+- `from_index` / `has_earlier` / `has_later` suggest windowed paging, but the
+  first request already returned 58 slots spanning two weeks.
+
+## Mixed Search API (unused)
+
+**GET** `https://oda.com/api/v1/search/mixed/?q=<query>&type=suggestion`
+
+Works unauthenticated and returns **search suggestions**, not search results:
+a `query_list` container (e.g. `trending_queries_list`) with query strings.
+Field names are snake_case here (`has_more_items`, `request_types`), unlike
+the camelCase hydration payload the HTML search pages carry.
+
+Full search results via this API (other `type` values) are undocumented; the
+CLI deliberately keeps parsing the HTML search pages, which carry complete
+product attributes and filters.
+
+## Saved List Pagination
+
+`GET /api/v1/product-lists/?filter=product_lists` is a standard DRF-paginated
+response: `{"next": <url|null>, "previous": <url|null>, "results": [...]}` -
+followers must walk `next` to see every list.
+
 ## Important Notes
 
 - Search and recipe data use **camelCase** field names (from React/Next.js)

--- a/src/index.ts
+++ b/src/index.ts
@@ -339,6 +339,19 @@ program
     }
   });
 
+// --- delivery commands ---
+const deliveryCmd = program
+  .command("delivery")
+  .description("Delivery information (read-only)");
+
+deliveryCmd
+  .command("slots")
+  .description("List upcoming delivery slots with ordering deadlines")
+  .action(async () => {
+    const client = makeClient();
+    console.log(JSON.stringify(await client.getDeliverySlots(), null, 2));
+  });
+
 // --- dump command (unchanged) ---
 program
   .command("dump <url>")

--- a/src/oda-client.ts
+++ b/src/oda-client.ts
@@ -11,6 +11,9 @@ import {
   SavedListItem,
   ProductSummary,
   CartRecommendation,
+  DeliverySlot,
+  DeliveryDay,
+  DeliverySlots,
 } from "./types.js";
 import fs from "fs";
 
@@ -492,6 +495,65 @@ export class OdaClient {
     }
     const html = await response.text();
     return this.extractJsonLd(html);
+  }
+
+  // --- Delivery slots (read-only) ---
+
+  /**
+   * Read the delivery slot picker: upcoming slots grouped by local calendar
+   * day, with per-slot ordering deadlines. Read-only - this client
+   * deliberately has no checkout or slot selection.
+   */
+  async getDeliverySlots(): Promise<DeliverySlots> {
+    const response = await this.apiGet(
+      `${OdaClient.API_BASE}/api/v1/slot-picker/slots/`,
+    );
+    if (!response.ok) {
+      await this.throwApiError("Get delivery slots", response);
+    }
+    const data = (await response.json()) as any;
+    const timeZone = data.time_zone || "Europe/Oslo";
+    const dateFormat = new Intl.DateTimeFormat("en-CA", {
+      timeZone,
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+    });
+
+    const days = new Map<string, DeliveryDay>();
+    for (const raw of data.delivery_slots || []) {
+      const priceLabel = String(raw.price ?? "");
+      const priceDigits = priceLabel.replace(/[^\d.,]/g, "").replace(",", ".");
+      const slot: DeliverySlot = {
+        id: raw.id,
+        starts_at: raw.open_datetime || "",
+        ends_at: raw.close_datetime || "",
+        deadline: raw.cutoff_time || "",
+        price: priceDigits ? parseFloat(priceDigits) : null,
+        price_label: priceLabel,
+        is_available: raw.is_full !== true && raw.is_unavailable !== true,
+      };
+      if (raw.is_cheapest === true) slot.is_cheapest = true;
+      if (raw.is_unavailable && raw.unavailable_description) {
+        slot.unavailable_description = raw.unavailable_description;
+      }
+
+      const date = slot.starts_at
+        ? dateFormat.format(new Date(slot.starts_at))
+        : "unknown";
+      let day = days.get(date);
+      if (!day) {
+        day = { date, slots: [] };
+        days.set(date, day);
+      }
+      day.slots.push(slot);
+    }
+
+    return {
+      time_zone: timeZone,
+      days: [...days.values()],
+      validation_messages: (data.validator_messages || []).map(String),
+    };
   }
 
   // --- Dump helper (for CLI discovery) ---

--- a/src/server.ts
+++ b/src/server.ts
@@ -249,6 +249,17 @@ export class OdaServer {
     );
 
     this.mcpServer.registerTool(
+      "delivery_get_slots",
+      {
+        description:
+          "List upcoming delivery slots grouped by day, with per-slot ordering deadlines and prices. Read-only: no slot can be selected and no order can be placed through this server.",
+      },
+      this.toolHandler("delivery_get_slots", async () => {
+        return this.jsonResult(await this.getClient().getDeliverySlots());
+      }),
+    );
+
+    this.mcpServer.registerTool(
       "products_search",
       {
         description: "Search for products on Oda.",

--- a/src/types.ts
+++ b/src/types.ts
@@ -83,3 +83,31 @@ export type CartRecommendation = ProductSummary;
 export interface SavedListDetail extends SavedList {
   items: SavedListItem[];
 }
+
+export interface DeliverySlot {
+  id: number;
+  starts_at: string;
+  ends_at: string;
+  /** Ordering deadline for this slot. */
+  deadline: string;
+  /** Numeric price parsed from the display string, when parseable. */
+  price: number | null;
+  price_label: string;
+  is_available: boolean;
+  is_cheapest?: boolean;
+  /** Why the slot is unavailable, when Oda says so (often cart-dependent). */
+  unavailable_description?: string;
+}
+
+export interface DeliveryDay {
+  /** Local calendar date (YYYY-MM-DD) in the store's time zone. */
+  date: string;
+  slots: DeliverySlot[];
+}
+
+export interface DeliverySlots {
+  time_zone: string;
+  days: DeliveryDay[];
+  /** Cart-dependent warnings, e.g. items not purchasable before a date. */
+  validation_messages: string[];
+}

--- a/tests/oda-client.test.ts
+++ b/tests/oda-client.test.ts
@@ -755,3 +755,92 @@ describe("OdaClient frequent products request volume", () => {
     expect(maxInFlight).toBeLessThanOrEqual(5);
   });
 });
+
+describe("OdaClient delivery slots", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("groups slots by local day and parses deadlines and prices", async () => {
+    const payload = {
+      time_zone: "Europe/Oslo",
+      delivery_slots: [
+        {
+          id: 1,
+          open_datetime: "2026-09-04T03:00:00Z",
+          close_datetime: "2026-09-04T05:00:00Z",
+          cutoff_time: "2026-09-03T18:00:00Z",
+          price: "kr 79",
+          is_full: false,
+          is_unavailable: false,
+          is_cheapest: true,
+        },
+        {
+          id: 2,
+          open_datetime: "2026-09-04T15:00:00Z",
+          close_datetime: "2026-09-04T17:00:00Z",
+          cutoff_time: "2026-09-04T10:00:00Z",
+          price: "kr 99",
+          is_full: true,
+          is_unavailable: false,
+        },
+        {
+          id: 3,
+          open_datetime: "2026-09-05T03:00:00Z",
+          close_datetime: "2026-09-05T05:00:00Z",
+          cutoff_time: "2026-09-04T18:00:00Z",
+          price: "kr 69",
+          is_full: false,
+          is_unavailable: true,
+          unavailable_description: "Ikke tilgjengelig",
+        },
+      ],
+      validator_messages: ["Noen varer er ikke tilgjengelige"],
+    };
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn()
+        .mockResolvedValue(apiResponse(200, vi.fn().mockResolvedValue(payload))),
+    );
+    const client = new OdaClient("/nonexistent/cookies.json");
+
+    const slots = await client.getDeliverySlots();
+    expect(slots.time_zone).toBe("Europe/Oslo");
+    expect(slots.validation_messages).toEqual([
+      "Noen varer er ikke tilgjengelige",
+    ]);
+    expect(slots.days.map((d) => d.date)).toEqual([
+      "2026-09-04",
+      "2026-09-05",
+    ]);
+
+    const [day1, day2] = slots.days;
+    expect(day1.slots).toHaveLength(2);
+    expect(day1.slots[0]).toMatchObject({
+      id: 1,
+      deadline: "2026-09-03T18:00:00Z",
+      price: 79,
+      price_label: "kr 79",
+      is_available: true,
+      is_cheapest: true,
+    });
+    expect(day1.slots[1].is_available).toBe(false);
+    expect(day2.slots[0]).toMatchObject({
+      is_available: false,
+      unavailable_description: "Ikke tilgjengelig",
+    });
+  });
+
+  it("raises with the auth hint on 403", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(apiResponse(403, vi.fn(), "forbidden")),
+    );
+    const client = new OdaClient("/nonexistent/cookies.json");
+
+    await expect(client.getDeliverySlots()).rejects.toThrow(
+      /Get delivery slots failed: HTTP 403/,
+    );
+  });
+});


### PR DESCRIPTION
Stacked on the docs branch (endpoint documented in ODA_API.md there).

`getDeliverySlots()`: `GET /api/v1/slot-picker/slots/` normalized to slots grouped by local calendar day (in the store's own time zone), each with the **ordering deadline** (`cutoff_time`), a parsed numeric price plus the original display label, availability (`is_full`/`is_unavailable` folded into one flag) and Oda's cart-dependent unavailability explanations. Top-level validation messages pass through — they warn about e.g. cart items not purchasable before a date.

- CLI: `oda delivery slots`
- MCP: `delivery_get_slots` (description states it is read-only)

**Deliberately read-only**: no slot selection and no checkout exist anywhere in this client, and that is unchanged. Answers "when can this be delivered and when do I have to order by" — the ordering itself stays in the app/browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U2e2Skyds2xUeDGsyUk8DS