### PR TITLE
fix: follow pagination when listing saved lists

### DIFF
--- a/src/oda-client.ts
+++ b/src/oda-client.ts
@@ -748,14 +748,29 @@ export class OdaClient {
   }
 
   async getSavedLists(): Promise<SavedList[]> {
-    const response = await this.apiGet(
-      `${OdaClient.API_BASE}/api/v1/product-lists/?filter=product_lists`,
-    );
-    if (!response.ok) {
-      await this.throwApiError("Get saved lists", response);
+    // DRF-paginated: follow `next` so accounts with many lists are not
+    // silently truncated. Guard against pagination loops like the order
+    // walk in getFrequentProducts does.
+    const lists: SavedList[] = [];
+    const visitedPages = new Set<string>();
+    let url: string | null =
+      `${OdaClient.API_BASE}/api/v1/product-lists/?filter=product_lists`;
+
+    while (url && !visitedPages.has(url)) {
+      visitedPages.add(url);
+      const response = await this.apiGet(url);
+      if (!response.ok) {
+        await this.throwApiError("Get saved lists", response);
+      }
+      const data = (await response.json()) as any;
+      for (const list of data.results || []) {
+        lists.push(this.parseSavedList(list));
+      }
+      url = data.next
+        ? OdaClient.resolveOdaUrl(String(data.next), "saved list pagination URL")
+        : null;
     }
-    const data = (await response.json()) as any;
-    return (data.results || []).map((list: any) => this.parseSavedList(list));
+    return lists;
   }
 
   async getSavedListDetails(listId: number): Promise<SavedListDetail> {

--- a/tests/oda-client.test.ts
+++ b/tests/oda-client.test.ts
@@ -755,3 +755,53 @@ describe("OdaClient frequent products request volume", () => {
     expect(maxInFlight).toBeLessThanOrEqual(5);
   });
 });
+
+describe("OdaClient saved list pagination", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  const listPage = (ids: number[], next: string | null) =>
+    apiResponse(
+      200,
+      vi.fn().mockResolvedValue({
+        next,
+        previous: null,
+        results: ids.map((id) => ({
+          id,
+          title: `Liste ${id}`,
+          description: "",
+          number_of_products: 1,
+          number_of_items: 1,
+          total_quantity: 1,
+          url: `/no/lists/${id}/`,
+        })),
+      }),
+    );
+
+  it("follows next links across pages", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        listPage([1, 2], "https://oda.com/api/v1/product-lists/?page=2"),
+      )
+      .mockResolvedValueOnce(listPage([3], null));
+    vi.stubGlobal("fetch", fetchMock);
+    const client = new OdaClient("/nonexistent/cookies.json");
+
+    const lists = await client.getSavedLists();
+    expect(lists.map((l) => l.id)).toEqual([1, 2, 3]);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("stops on a pagination loop", async () => {
+    const url = "https://oda.com/api/v1/product-lists/?filter=product_lists";
+    const fetchMock = vi.fn().mockResolvedValue(listPage([1], url));
+    vi.stubGlobal("fetch", fetchMock);
+    const client = new OdaClient("/nonexistent/cookies.json");
+
+    const lists = await client.getSavedLists();
+    expect(lists.map((l) => l.id)).toEqual([1]);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
`/api/v1/product-lists/` is a standard DRF-paginated response; the client read only the first `results` page, silently truncating accounts with many lists. Walk the `next` links with the same loop guard and same-origin URL check the order pagination already uses.

Two unit tests: multi-page walk, and loop protection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U2e2Skyds2xUeDGsyUk8DS