### PR TITLE
fix(cli): exit explicitly after command completion

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -377,9 +377,27 @@ program
     }
   });
 
-program.parse();
-
 process.on("unhandledRejection", (err) => {
   console.error(err);
+  process.exit(1);
+});
+
+// Some Oda pages (recipe pages, notably) leave a referenced keep-alive
+// socket behind after the response body is fully consumed, so the event
+// loop never drains and the process hangs after the command has finished.
+// Exit explicitly once the command action resolves - except for the MCP
+// server, which must keep running on stdio.
+async function main() {
+  await program.parseAsync();
+  if (program.args[0] === "mcp") return;
+  // Let queued stdout writes drain before exiting.
+  await new Promise<void>((resolve) => {
+    process.stdout.write("", () => resolve());
+  });
+  process.exit(0);
+}
+
+main().catch((err) => {
+  console.error(err instanceof Error ? err.message : err);
   process.exit(1);
 });


### PR DESCRIPTION
Every `recipe` CLI command hangs forever after printing its result: recipe pages leave a **referenced** keep-alive TLS socket behind even after the response body is fully consumed, so the event loop never drains. Minimal repro (hangs, exit only via timeout):

```js
const r = await fetch("https://oda.com/no/recipes/5036-laks-med-kremet-sitronpasta/", {headers: {"User-Agent": "Mozilla/5.0"}});
await r.text();
// process never exits; process._getActiveHandles() shows a TLSSocket
```

Search/cart pages don't trigger it — something about the recipe page response keeps undici's socket referenced.

Fix in the CLI: switch to `parseAsync`, then `process.exit(0)` once the action resolves, after letting queued stdout writes drain. The `mcp` command is exempt — the server must keep running on stdio (verified it still does). Action rejections now print the error message and exit 1 instead of an unhandled-rejection stack.

Verified: `recipe details 5036` returns in ~2 s with exit 0 (previously hung indefinitely on main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U2e2Skyds2xUeDGsyUk8DS